### PR TITLE
Add `compute_loss` method to `Model`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ misc/
 runs/
 checkpoints/
 data/
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dmypy.json
 misc/
 runs/
 checkpoints/
+data/

--- a/hezar/constants.py
+++ b/hezar/constants.py
@@ -89,6 +89,20 @@ class RegistryType(str, Enum):
     METRIC = "metric"
 
 
+class LossType(str, Enum):
+    L1 = "l1"
+    NLL = "nll"
+    NLL_2D = "nll_2d"
+    POISSON_NLL = "poisson_nll"
+    GAUSSIAN_NLL = "gaussian_nll"
+    MSE = "mse"
+    BCE = "bce"
+    BCE_WITH_LOGITS = "bce_with_logits"
+    CROSS_ENTROPY = "cross_entropy"
+    TRIPLE_MARGIN = "triple_margin"
+    CTC = "ctc"
+
+
 class SplitType(str, Enum):
     TRAIN = "train"
     EVAL = "eval"

--- a/hezar/models/image2text/beit_roberta/beit_roberta_image2text.py
+++ b/hezar/models/image2text/beit_roberta/beit_roberta_image2text.py
@@ -64,6 +64,7 @@ class BeitRobertaImage2Text(Model):
             encoder_outputs=encoder_outputs,
             past_key_values=past_key_values,
             decoder_inputs_embeds=decoder_inputs_embeds,
+            labels=None,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,

--- a/hezar/models/image2text/beit_roberta/beit_roberta_image2text.py
+++ b/hezar/models/image2text/beit_roberta/beit_roberta_image2text.py
@@ -37,6 +37,7 @@ class BeitRobertaImage2Text(Model):
     required_backends = _required_backends
     image_processor = "image_processor"
     tokenizer = "bpe_tokenizer"
+    loss_fn = "cross_entropy"
 
     def __init__(self, config: BeitRobertaImage2TextConfig, **kwargs):
         super().__init__(config, **kwargs)
@@ -73,8 +74,7 @@ class BeitRobertaImage2Text(Model):
         return outputs
 
     def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        criterion = torch.nn.CrossEntropyLoss()
-        loss = criterion(logits.reshape(-1, self.beit_roberta.decoder.config.vocab_size), labels.reshape(-1))
+        loss = self.criterion(logits.reshape(-1, self.beit_roberta.decoder.config.vocab_size), labels.reshape(-1))
         return loss
 
     def generate(self, pixel_values, generation_config=None, **kwargs):

--- a/hezar/models/image2text/beit_roberta/beit_roberta_image2text.py
+++ b/hezar/models/image2text/beit_roberta/beit_roberta_image2text.py
@@ -52,7 +52,6 @@ class BeitRobertaImage2Text(Model):
         encoder_outputs=None,
         past_key_values=None,
         decoder_inputs_embeds=None,
-        labels=None,
         use_cache=None,
         output_attentions=None,
         output_hidden_states=None,
@@ -65,13 +64,17 @@ class BeitRobertaImage2Text(Model):
             encoder_outputs=encoder_outputs,
             past_key_values=past_key_values,
             decoder_inputs_embeds=decoder_inputs_embeds,
-            labels=labels,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
 
         return outputs
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = torch.nn.CrossEntropyLoss()
+        loss = criterion(logits.reshape(-1, self.beit_roberta.decoder.config.vocab_size), labels.reshape(-1))
+        return loss
 
     def generate(self, pixel_values, generation_config=None, **kwargs):
         if generation_config is None:

--- a/hezar/models/image2text/crnn/crnn_image2text.py
+++ b/hezar/models/image2text/crnn/crnn_image2text.py
@@ -1,3 +1,4 @@
+import torch
 from torch import nn
 
 from ....registry import register_model
@@ -52,6 +53,20 @@ class CRNNImage2Text(Model):
         x = self.classifier(x)
         x = nn.functional.log_softmax(x, 2)
         return x
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor, labels_lengths: torch.Tensor = None):
+        if labels_lengths is None:
+            raise ValueError(f"CRNN requires `labels_lengths` to compute loss!")
+
+        criterion = nn.CTCLoss(reduction="sum")
+
+        labels_lengths = torch.flatten(labels_lengths)
+        batch_size = logits.size(1)
+        input_lengths = torch.LongTensor([logits.size(0) * batch_size])
+
+        loss = criterion(logits, labels, input_lengths, labels_lengths) / batch_size
+
+        return loss
 
     def generate(self, pixel_values, **kwargs):
         logits = self(pixel_values)

--- a/hezar/models/image2text/crnn/crnn_image2text.py
+++ b/hezar/models/image2text/crnn/crnn_image2text.py
@@ -16,6 +16,7 @@ class CRNNImage2Text(Model):
 
     is_generative = True
     image_processor = "image_processor"
+    loss_fn = "ctc"
 
     def __init__(self, config: CRNNImage2TextConfig, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -54,17 +55,12 @@ class CRNNImage2Text(Model):
         x = nn.functional.log_softmax(x, 2)
         return x
 
-    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor, labels_lengths: torch.Tensor = None):
-        if labels_lengths is None:
-            raise ValueError(f"CRNN requires `labels_lengths` to compute loss!")
-
-        criterion = nn.CTCLoss(reduction="sum")
-
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor, labels_lengths: torch.Tensor):
         labels_lengths = torch.flatten(labels_lengths)
         batch_size = logits.size(1)
         input_lengths = torch.LongTensor([logits.size(0) * batch_size])
 
-        loss = criterion(logits, labels, input_lengths, labels_lengths) / batch_size
+        loss = self.criterion(logits, labels, input_lengths, labels_lengths) / batch_size
 
         return loss
 

--- a/hezar/models/image2text/trocr/trocr_image2text.py
+++ b/hezar/models/image2text/trocr/trocr_image2text.py
@@ -52,7 +52,6 @@ class TrOCRImage2Text(Model):
         encoder_outputs=None,
         past_key_values=None,
         decoder_inputs_embeds=None,
-        labels=None,
         use_cache=None,
         output_attentions=None,
         output_hidden_states=None,
@@ -65,13 +64,17 @@ class TrOCRImage2Text(Model):
             encoder_outputs=encoder_outputs,
             past_key_values=past_key_values,
             decoder_inputs_embeds=decoder_inputs_embeds,
-            labels=labels,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
 
         return outputs
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = torch.nn.CrossEntropyLoss()
+        loss = criterion(logits.reshape(-1, self.trocr.decoder.config.vocab_size), labels.reshape(-1))
+        return loss
 
     def generate(self, pixel_values, generation_config=None, **kwargs):
         if generation_config is None:

--- a/hezar/models/image2text/trocr/trocr_image2text.py
+++ b/hezar/models/image2text/trocr/trocr_image2text.py
@@ -64,6 +64,7 @@ class TrOCRImage2Text(Model):
             encoder_outputs=encoder_outputs,
             past_key_values=past_key_values,
             decoder_inputs_embeds=decoder_inputs_embeds,
+            labels=None,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,

--- a/hezar/models/image2text/trocr/trocr_image2text.py
+++ b/hezar/models/image2text/trocr/trocr_image2text.py
@@ -37,6 +37,7 @@ class TrOCRImage2Text(Model):
     required_backends = _required_backends
     image_processor = "image_processor"
     tokenizer = "bpe_tokenizer"
+    loss_fn = "cross_entropy"
 
     def __init__(self, config: TrOCRImage2TextConfig, **kwargs):
         super().__init__(config, **kwargs)
@@ -73,8 +74,7 @@ class TrOCRImage2Text(Model):
         return outputs
 
     def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        criterion = torch.nn.CrossEntropyLoss()
-        loss = criterion(logits.reshape(-1, self.trocr.decoder.config.vocab_size), labels.reshape(-1))
+        loss = self.criterion(logits.reshape(-1, self.trocr.decoder.config.vocab_size), labels.reshape(-1))
         return loss
 
     def generate(self, pixel_values, generation_config=None, **kwargs):

--- a/hezar/models/image2text/vit_gpt2/vit_gpt2_image2text.py
+++ b/hezar/models/image2text/vit_gpt2/vit_gpt2_image2text.py
@@ -52,7 +52,6 @@ class ViTGPT2Image2Text(Model):
         encoder_outputs=None,
         past_key_values=None,
         decoder_inputs_embeds=None,
-        labels=None,
         use_cache=None,
         output_attentions=None,
         output_hidden_states=None,
@@ -65,13 +64,17 @@ class ViTGPT2Image2Text(Model):
             encoder_outputs=encoder_outputs,
             past_key_values=past_key_values,
             decoder_inputs_embeds=decoder_inputs_embeds,
-            labels=labels,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
 
         return outputs
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = torch.nn.CrossEntropyLoss()
+        loss = criterion(logits.reshape(-1, self.vit_gpt2.decoder.config.vocab_size), labels.reshape(-1))
+        return loss
 
     def generate(self, pixel_values, generation_config=None, **kwargs):
         if generation_config is None:

--- a/hezar/models/image2text/vit_gpt2/vit_gpt2_image2text.py
+++ b/hezar/models/image2text/vit_gpt2/vit_gpt2_image2text.py
@@ -37,6 +37,7 @@ class ViTGPT2Image2Text(Model):
     required_backends = _required_backends
     image_processor = "image_processor"
     tokenizer = "bpe_tokenizer"
+    loss_fn = "cross_entropy"
 
     def __init__(self, config: ViTGPT2Image2TextConfig, **kwargs):
         super().__init__(config, **kwargs)
@@ -73,8 +74,7 @@ class ViTGPT2Image2Text(Model):
         return outputs
 
     def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        criterion = torch.nn.CrossEntropyLoss()
-        loss = criterion(logits.reshape(-1, self.vit_gpt2.decoder.config.vocab_size), labels.reshape(-1))
+        loss = self.criterion(logits.reshape(-1, self.vit_gpt2.decoder.config.vocab_size), labels.reshape(-1))
         return loss
 
     def generate(self, pixel_values, generation_config=None, **kwargs):

--- a/hezar/models/image2text/vit_gpt2/vit_gpt2_image2text.py
+++ b/hezar/models/image2text/vit_gpt2/vit_gpt2_image2text.py
@@ -64,6 +64,7 @@ class ViTGPT2Image2Text(Model):
             encoder_outputs=encoder_outputs,
             past_key_values=past_key_values,
             decoder_inputs_embeds=decoder_inputs_embeds,
+            labels=None,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,

--- a/hezar/models/image2text/vit_roberta/vit_roberta_image2text.py
+++ b/hezar/models/image2text/vit_roberta/vit_roberta_image2text.py
@@ -37,6 +37,7 @@ class ViTRobertaImage2Text(Model):
     required_backends = _required_backends
     image_processor = "image_processor"
     tokenizer = "bpe_tokenizer"
+    loss_fn = "cross_entropy"
 
     def __init__(self, config: ViTRobertaImage2TextConfig, **kwargs):
         super().__init__(config, **kwargs)
@@ -73,8 +74,7 @@ class ViTRobertaImage2Text(Model):
         return outputs
 
     def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        criterion = torch.nn.CrossEntropyLoss()
-        loss = criterion(logits.reshape(-1, self.vit_roberta.decoder.config.vocab_size), labels.reshape(-1))
+        loss = self.criterion(logits.reshape(-1, self.vit_roberta.decoder.config.vocab_size), labels.reshape(-1))
         return loss
 
     def generate(self, pixel_values, generation_config=None, **kwargs):

--- a/hezar/models/image2text/vit_roberta/vit_roberta_image2text.py
+++ b/hezar/models/image2text/vit_roberta/vit_roberta_image2text.py
@@ -64,6 +64,7 @@ class ViTRobertaImage2Text(Model):
             encoder_outputs=encoder_outputs,
             past_key_values=past_key_values,
             decoder_inputs_embeds=decoder_inputs_embeds,
+            labels=None,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,

--- a/hezar/models/image2text/vit_roberta/vit_roberta_image2text.py
+++ b/hezar/models/image2text/vit_roberta/vit_roberta_image2text.py
@@ -52,7 +52,6 @@ class ViTRobertaImage2Text(Model):
         encoder_outputs=None,
         past_key_values=None,
         decoder_inputs_embeds=None,
-        labels=None,
         use_cache=None,
         output_attentions=None,
         output_hidden_states=None,
@@ -65,13 +64,17 @@ class ViTRobertaImage2Text(Model):
             encoder_outputs=encoder_outputs,
             past_key_values=past_key_values,
             decoder_inputs_embeds=decoder_inputs_embeds,
-            labels=labels,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
 
         return outputs
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = torch.nn.CrossEntropyLoss()
+        loss = criterion(logits.reshape(-1, self.vit_roberta.decoder.config.vocab_size), labels.reshape(-1))
+        return loss
 
     def generate(self, pixel_values, generation_config=None, **kwargs):
         tokenizer = self.preprocessor["bpe_tokenizer"]

--- a/hezar/models/language_modeling/bert/bert_lm.py
+++ b/hezar/models/language_modeling/bert/bert_lm.py
@@ -63,6 +63,11 @@ class BertLM(Model):
 
         return outputs
 
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = torch.nn.CrossEntropyLoss()
+        loss = criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
+        return loss
+
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]
@@ -85,9 +90,7 @@ class BertLM(Model):
         filled_token_ids = token_ids.cpu().numpy().copy()
         fill_tokens = []
         for batch_i, logits in enumerate(output_logits):
-            masked_index = torch.nonzero(
-                token_ids[batch_i] == tokenizer.mask_token_id, as_tuple=False
-            ).flatten()  # noqa
+            masked_index = torch.nonzero(token_ids[batch_i] == tokenizer.mask_token_id, as_tuple=False).flatten()  # noqa
             if len(masked_index) > 1:
                 raise ValueError(
                     f"Can't handle multiple `{tokenizer.mask_token}` tokens in the input for {self.__class__.__name__}!"

--- a/hezar/models/language_modeling/bert/bert_lm.py
+++ b/hezar/models/language_modeling/bert/bert_lm.py
@@ -27,6 +27,7 @@ class BertLM(Model):
     required_backends = _required_backends
     tokenizer_name = "wordpiece_tokenizer"
     skip_keys_on_load = ["model.embeddings.position_ids", "bert.embeddings.position_ids"]  # For older versions
+    loss_fn = "cross_entropy"
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -65,8 +66,7 @@ class BertLM(Model):
         return outputs
 
     def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        criterion = torch.nn.CrossEntropyLoss()
-        loss = criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
+        loss = self.criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
         return loss
 
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):

--- a/hezar/models/language_modeling/bert/bert_lm.py
+++ b/hezar/models/language_modeling/bert/bert_lm.py
@@ -55,6 +55,7 @@ class BertLM(Model):
             inputs_embeds=inputs_embeds,
             encoder_hidden_states=encoder_hidden_states,
             encoder_attention_mask=encoder_attention_mask,
+            labels=None,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=True,

--- a/hezar/models/language_modeling/distilbert/distilbert_lm.py
+++ b/hezar/models/language_modeling/distilbert/distilbert_lm.py
@@ -26,6 +26,7 @@ _required_backends = [
 class DistilBertLM(Model):
     required_backends = _required_backends
     tokenizer_name = "wordpiece_tokenizer"
+    loss_fn = "cross_entropy"
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -57,8 +58,7 @@ class DistilBertLM(Model):
         return outputs
 
     def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        criterion = torch.nn.CrossEntropyLoss()
-        loss = criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
+        loss = self.criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
         return loss
 
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):

--- a/hezar/models/language_modeling/distilbert/distilbert_lm.py
+++ b/hezar/models/language_modeling/distilbert/distilbert_lm.py
@@ -46,6 +46,7 @@ class DistilBertLM(Model):
             attention_mask=attention_mask,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
+            labels=None,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=True,

--- a/hezar/models/language_modeling/distilbert/distilbert_lm.py
+++ b/hezar/models/language_modeling/distilbert/distilbert_lm.py
@@ -55,6 +55,11 @@ class DistilBertLM(Model):
 
         return outputs
 
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = torch.nn.CrossEntropyLoss()
+        loss = criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
+        return loss
+
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]

--- a/hezar/models/language_modeling/roberta/roberta_lm.py
+++ b/hezar/models/language_modeling/roberta/roberta_lm.py
@@ -27,6 +27,7 @@ class RobertaLM(Model):
     required_backends = _required_backends
     tokenizer_name = "bpe_tokenizer"
     skip_keys_on_load = ["model.embeddings.position_ids", "roberta.embeddings.position_ids"]  # For older versions
+    loss_fn = "cross_entropy"
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -64,8 +65,7 @@ class RobertaLM(Model):
         return outputs
 
     def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        criterion = torch.nn.CrossEntropyLoss()
-        loss = criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
+        loss = self.criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
         return loss
 
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):

--- a/hezar/models/language_modeling/roberta/roberta_lm.py
+++ b/hezar/models/language_modeling/roberta/roberta_lm.py
@@ -55,6 +55,7 @@ class RobertaLM(Model):
             inputs_embeds=inputs_embeds,
             encoder_hidden_states=encoder_hidden_states,
             encoder_attention_mask=encoder_attention_mask,
+            labels=None,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )

--- a/hezar/models/language_modeling/roberta/roberta_lm.py
+++ b/hezar/models/language_modeling/roberta/roberta_lm.py
@@ -62,6 +62,11 @@ class RobertaLM(Model):
 
         return outputs
 
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = torch.nn.CrossEntropyLoss()
+        loss = criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
+        return loss
+
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]

--- a/hezar/models/model.py
+++ b/hezar/models/model.py
@@ -267,6 +267,19 @@ class Model(nn.Module):
         """
         raise NotImplementedError
 
+    def compute_loss(self, inputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        """
+        Compute loss on the model outputs against the given labels
+
+        Args:
+            inputs: Input tensor to compute loss on
+            targets: Target tensor
+
+        Returns:
+            Loss tensor
+        """
+        raise NotImplementedError
+
     def generate(self, *model_inputs, **kwargs):
         """
         Generation method for all generative models. Generative models have the `is_generative` attribute set to True.

--- a/hezar/models/model.py
+++ b/hezar/models/model.py
@@ -24,18 +24,32 @@ from ..constants import (
     DEFAULT_MODEL_FILE,
     HEZAR_CACHE_DIR,
     Backends,
+    LossType,
 )
 from ..preprocessors import Preprocessor, PreprocessorsContainer
 from ..utils import Logger, verify_dependencies
 from .model_outputs import ModelOutput
 
-
 logger = Logger(__name__)
+
+criterions_mapping = {
+    "l1": nn.L1Loss,
+    "nll": nn.NLLLoss,
+    "nll_2d": nn.NLLLoss2d,
+    "poisson_nll": nn.PoissonNLLLoss,
+    "gaussian_nll": nn.GaussianNLLLoss,
+    "mse": nn.MSELoss,
+    "bce": nn.BCELoss,
+    "bce_with_logits": nn.BCEWithLogitsLoss,
+    "cross_entropy": nn.CrossEntropyLoss,
+    "triple_margin": nn.TripletMarginLoss,
+    "ctc": nn.CTCLoss
+}
 
 
 class Model(nn.Module):
     """
-    A base model for all neural-based models in Hezar.
+    Base class for all neural network models in Hezar.
 
     Args:
         config: A dataclass model config
@@ -52,11 +66,22 @@ class Model(nn.Module):
     # Keys to ignore on loading state dicts
     skip_keys_on_load = []
 
+    # Loss function name
+    loss_fn: Union[str, LossType] = LossType.CROSS_ENTROPY
+
     def __init__(self, config: ModelConfig, *args, **kwargs):
         verify_dependencies(self, self.required_backends)
         super().__init__()
         self.config = config.update(kwargs)
         self._preprocessor = None
+        self._criterion = self._set_criterion(self.loss_fn)
+
+    @staticmethod
+    def _set_criterion(criterion_name: str):
+        if criterion_name not in criterions_mapping:
+            raise ValueError(f"Invalid criterion name `{criterion_name}`. Available: {list(criterions_mapping.keys())}")
+        loss_fn = criterions_mapping[criterion_name]()
+        return loss_fn
 
     @classmethod
     def load(
@@ -451,6 +476,19 @@ class Model(nn.Module):
         Get the model's device. This method is only safe when all weights of the model are on the same device.
         """
         return next(self.parameters()).device
+
+    @property
+    def criterion(self):
+        return self._criterion
+
+    @criterion.setter
+    def criterion(self, value):
+        if isinstance(value, str):
+            self._criterion = self._set_criterion(value)
+        elif isinstance(value, nn.Module):
+            self._criterion = value
+        else:
+            raise ValueError(f"Criterion value must be either a name or a PyTorch `nn.Module`, got {type(value)}!")
 
     @property
     def preprocessor(self) -> PreprocessorsContainer:

--- a/hezar/models/sequence_labeling/bert/bert_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/bert/bert_sequence_labeling.py
@@ -3,7 +3,8 @@ A BERT model for sequence labeling built using HuggingFace Transformers
 """
 from typing import Dict, List, Union
 
-from torch import nn
+import torch
+import torch.nn as nn
 
 from ....constants import Backends
 from ....registry import register_model
@@ -82,6 +83,11 @@ class BertSequenceLabeling(Model):
             "tokens": kwargs.get("tokens", None),
         }
         return outputs
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = nn.CrossEntropyLoss()
+        loss = criterion(logits.view(-1, self.config.num_labels), labels.view(-1))
+        return loss
 
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):
         if isinstance(inputs, str):

--- a/hezar/models/sequence_labeling/distilbert/distilbert_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/distilbert/distilbert_sequence_labeling.py
@@ -3,6 +3,7 @@ A DISTILBERT model for sequence labeling built using HuggingFace Transformers
 """
 from typing import Dict, List, Union
 
+import torch
 from torch import nn
 
 from ....constants import Backends
@@ -78,6 +79,11 @@ class DistilBertSequenceLabeling(Model):
             "tokens": kwargs.get("tokens", None),
         }
         return outputs
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = nn.CrossEntropyLoss()
+        loss = criterion(logits.view(-1, self.config.num_labels), labels.view(-1))
+        return loss
 
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):
         if isinstance(inputs, str):

--- a/hezar/models/sequence_labeling/roberta/roberta_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/roberta/roberta_sequence_labeling.py
@@ -3,6 +3,7 @@ A RoBERTa Language Model (HuggingFace Transformers) wrapped by a Hezar Model cla
 """
 from typing import List, Union
 
+import torch
 from torch import nn, tanh
 
 from ....constants import Backends
@@ -81,6 +82,11 @@ class RobertaSequenceLabeling(Model):
             "tokens": kwargs.get("tokens", None),
         }
         return outputs
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = nn.CrossEntropyLoss()
+        loss = criterion(logits.view(-1, self.config.num_labels), labels.view(-1))
+        return loss
 
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):
         if isinstance(inputs, str):

--- a/hezar/models/speech_recognition/whisper/whisper_speech_recognition.py
+++ b/hezar/models/speech_recognition/whisper/whisper_speech_recognition.py
@@ -66,6 +66,7 @@ class WhisperSpeechRecognition(Model):
             encoder_outputs=encoder_outputs,
             past_key_values=past_key_values,
             decoder_inputs_embeds=decoder_inputs_embeds,
+            labels=None,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,

--- a/hezar/models/speech_recognition/whisper/whisper_speech_recognition.py
+++ b/hezar/models/speech_recognition/whisper/whisper_speech_recognition.py
@@ -33,6 +33,7 @@ class WhisperSpeechRecognition(Model):
     required_backends = _required_backends
     feature_extractor_name = "whisper_feature_extractor"
     tokenizer_name = "whisper_bpe_tokenizer"
+    loss_fn = "cross_entropy"
 
     def __init__(self, config: WhisperSpeechRecognitionConfig, **kwargs):
         super().__init__(config, **kwargs)
@@ -75,8 +76,7 @@ class WhisperSpeechRecognition(Model):
         return outputs
 
     def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        criterion = nn.CrossEntropyLoss()
-        loss = criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
+        loss = self.criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
         return loss
 
     def generate(

--- a/hezar/models/speech_recognition/whisper/whisper_speech_recognition.py
+++ b/hezar/models/speech_recognition/whisper/whisper_speech_recognition.py
@@ -2,6 +2,7 @@ from typing import List, Union
 
 import numpy as np
 import torch
+from torch import nn
 
 from ....constants import Backends
 from ....registry import register_model
@@ -49,7 +50,6 @@ class WhisperSpeechRecognition(Model):
         encoder_outputs=None,
         past_key_values=None,
         decoder_inputs_embeds=None,
-        labels=None,
         use_cache=None,
         output_attentions=None,
         output_hidden_states=None,
@@ -66,13 +66,17 @@ class WhisperSpeechRecognition(Model):
             encoder_outputs=encoder_outputs,
             past_key_values=past_key_values,
             decoder_inputs_embeds=decoder_inputs_embeds,
-            labels=labels,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
 
         return outputs
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = nn.CrossEntropyLoss()
+        loss = criterion(logits.view(-1, self.config.vocab_size), labels.view(-1))
+        return loss
 
     def generate(
         self,

--- a/hezar/models/text_classification/bert/bert_text_classification.py
+++ b/hezar/models/text_classification/bert/bert_text_classification.py
@@ -3,6 +3,7 @@ A BERT model for text classification built using HuggingFace Transformers
 """
 from typing import Dict, List, Union
 
+import torch
 from torch import nn
 
 from ....constants import Backends
@@ -56,6 +57,11 @@ class BertTextClassification(Model):
             self.config.num_labels = len(self.config.id2label)
         bert_config = BertConfig(**self.config)
         return bert_config
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = nn.CrossEntropyLoss()
+        loss = criterion(logits.view(-1, self.config.num_labels), labels.view(-1))
+        return loss
 
     def forward(
         self,

--- a/hezar/models/text_classification/distilbert/distilbert_text_classification.py
+++ b/hezar/models/text_classification/distilbert/distilbert_text_classification.py
@@ -3,6 +3,7 @@ A DistilBERT model for text classification built using HuggingFace Transformers
 """
 from typing import Dict, List, Union
 
+import torch
 from torch import nn
 
 from ....constants import Backends
@@ -80,6 +81,11 @@ class DistilBertTextClassification(Model):
             "attentions": lm_outputs.attentions,
         }
         return outputs
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = nn.CrossEntropyLoss()
+        loss = criterion(logits.view(-1, self.config.num_labels), labels.view(-1))
+        return loss
 
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):
         if isinstance(inputs, str):

--- a/hezar/models/text_classification/roberta/roberta_text_classification.py
+++ b/hezar/models/text_classification/roberta/roberta_text_classification.py
@@ -3,6 +3,7 @@ A RoBERTa Language Model (HuggingFace Transformers) wrapped by a Hezar Model cla
 """
 from typing import Dict, List, Union
 
+import torch
 from torch import nn, tanh
 
 from ....constants import Backends
@@ -80,6 +81,11 @@ class RobertaTextClassification(Model):
             "attentions": lm_outputs.attentions,
         }
         return outputs
+
+    def compute_loss(self, inputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        criterion = nn.CrossEntropyLoss()
+        loss = criterion(inputs.view(-1, self.config.num_labels), targets.view(-1))
+        return loss
 
     def preprocess(self, inputs: Union[str, List[str]], **kwargs):
         if isinstance(inputs, str):

--- a/hezar/models/text_generation/t5/t5_text_generation.py
+++ b/hezar/models/text_generation/t5/t5_text_generation.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Union
 
 import torch
+import torch.nn as nn
 
 from ....constants import Backends
 from ....registry import register_model
@@ -46,7 +47,6 @@ class T5TextGeneration(Model):
         past_key_values=None,
         inputs_embeds=None,
         decoder_inputs_embeds=None,
-        labels=None,
         use_cache=None,
         output_attentions=None,
         output_hidden_states=None,
@@ -64,13 +64,17 @@ class T5TextGeneration(Model):
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
             decoder_inputs_embeds=decoder_inputs_embeds,
-            labels=labels,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
 
         return outputs
+
+    def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        criterion = nn.CrossEntropyLoss()
+        loss = criterion(logits.view(-1, logits.size(-1)), labels.view(-1))
+        return loss
 
     def generate(self, token_ids, attention_mask=None, **kwargs):
         input_bs, input_length = token_ids.shape

--- a/hezar/models/text_generation/t5/t5_text_generation.py
+++ b/hezar/models/text_generation/t5/t5_text_generation.py
@@ -64,6 +64,7 @@ class T5TextGeneration(Model):
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
             decoder_inputs_embeds=decoder_inputs_embeds,
+            labels=None,
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,

--- a/hezar/models/text_generation/t5/t5_text_generation.py
+++ b/hezar/models/text_generation/t5/t5_text_generation.py
@@ -28,6 +28,7 @@ class T5TextGeneration(Model):
     is_generative = True
     required_backends = _required_backends
     tokenizer_name = "sentencepiece_unigram_tokenizer"
+    loss_fn = "cross_entropy"
 
     def __init__(self, config: T5TextGenerationConfig, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -73,8 +74,7 @@ class T5TextGeneration(Model):
         return outputs
 
     def compute_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        criterion = nn.CrossEntropyLoss()
-        loss = criterion(logits.view(-1, logits.size(-1)), labels.view(-1))
+        loss = self.criterion(logits.view(-1, logits.size(-1)), labels.view(-1))
         return loss
 
     def generate(self, token_ids, attention_mask=None, **kwargs):


### PR DESCRIPTION
This PR adds `compute_loss` method as the primary method for calculating loss. 

We made this decision since the models with the same task do not necessarily follow the same pattern for computing loss. That's why most libraries compute loss in their forward method. Although we took a slighly different approach. Instead of messing up all forward methods with an if statement for computing loss which is inaccessible for the end user, we added a seperate method for this purpose.
This method takes in two main inputs as `inputs` and `targets`. Subclasses can override this notation.
