### PR TITLE
Prediction outputs refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ print(transcripts)
 ```python
 from hezar import Model
 # OCR with TrOCR
-model = Model.load("hezarai/trocr-base-fa-v1")
+model = Model.load("hezarai/trocr-base-fa-v2")
 texts = model.predict(["examples/assets/ocr_example.jpg"])
 print(f"TrOCR Output: {texts}")
 
@@ -116,8 +116,8 @@ texts = model.predict("examples/assets/ocr_example.jpg")
 print(f"CRNN Output: {texts}")
 ```
 ```
-TrOCR Output: {'texts': [' چه میشه کرد، باید صبر کنیم']}
-CRNN Output: {'texts': ['چه میشه کرد، باید صبر کنیم']}
+TrOCR Output: [{'text': 'چه میشه کرد، باید صبر کنیم'}]
+CRNN Output: [{'text': 'چه میشه کرد، باید صبر کنیم'}]
 ```
 ![](https://raw.githubusercontent.com/hezarai/hezar/main/examples/assets/ocr_example.jpg)
 
@@ -130,7 +130,7 @@ plate_text = model.predict("assets/license_plate_ocr_example.jpg")
 print(plate_text)  # Persian text of mixed numbers and characters might not show correctly in the console
 ```
 ```
-{'texts': ['۵۷س۷۷۹۷۷']}
+[{'text': '۵۷س۷۷۹۷۷'}]
 ```
 ![](https://raw.githubusercontent.com/hezarai/hezar/main/examples/assets/license_plate_ocr_example.jpg)
 
@@ -143,7 +143,7 @@ texts = model.predict("examples/assets/image_captioning_example.jpg")
 print(texts)
 ```
 ```
-{'texts': ['سگی با توپ تنیس در دهانش می دود.']}
+[{'text': 'سگی با توپ تنیس در دهانش می دود.'}]
 ```
 ![](https://raw.githubusercontent.com/hezarai/hezar/main/examples/assets/image_captioning_example.jpg)
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ transcripts = whisper.predict("examples/assets/speech_example.mp3")
 print(transcripts)
 ```
 ```
-{'transcripts': ['و این تنها محدود به محیط کار نیست']}
+[{'text': 'و این تنها محدود به محیط کار نیست'}]
 ```
 - **Image to Text (OCR)**
 ```python

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ print(f"POS: {pos_outputs}")
 print(f"NER: {ner_outputs}")
 ```
 ```
-POS: [[{'token': 'شرکت', 'tag': 'Ne'}, {'token': 'هوش', 'tag': 'Ne'}, {'token': 'مصنوعی', 'tag': 'AJe'}, {'token': 'هزار', 'tag': 'NUM'}]]
-NER: [[{'token': 'شرکت', 'tag': 'B-org'}, {'token': 'هوش', 'tag': 'I-org'}, {'token': 'مصنوعی', 'tag': 'I-org'}, {'token': 'هزار', 'tag': 'I-org'}]]
+POS: [[{'token': 'شرکت', 'label': 'Ne'}, {'token': 'هوش', 'label': 'Ne'}, {'token': 'مصنوعی', 'label': 'AJe'}, {'token': 'هزار', 'label': 'NUM'}]]
+NER: [[{'token': 'شرکت', 'label': 'B-org'}, {'token': 'هوش', 'label': 'I-org'}, {'token': 'مصنوعی', 'label': 'I-org'}, {'token': 'هزار', 'label': 'I-org'}]]
 ```
 - **Language Modeling (Mask Filling)**
 ```python

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ outputs = model.predict(example)
 print(outputs)
 ```
 ```
-{'labels': ['positive'], 'probs': [0.812910258769989]}
+[[{'label': 'positive', 'score': 0.812910258769989}]]
 ```
 - **Sequence Labeling (POS, NER, etc.)**
 ```python

--- a/README.md
+++ b/README.md
@@ -79,17 +79,17 @@ print(f"NER: {ner_outputs}")
 POS: [[{'token': 'شرکت', 'tag': 'Ne'}, {'token': 'هوش', 'tag': 'Ne'}, {'token': 'مصنوعی', 'tag': 'AJe'}, {'token': 'هزار', 'tag': 'NUM'}]]
 NER: [[{'token': 'شرکت', 'tag': 'B-org'}, {'token': 'هوش', 'tag': 'I-org'}, {'token': 'مصنوعی', 'tag': 'I-org'}, {'token': 'هزار', 'tag': 'I-org'}]]
 ```
-- **Language Modeling**
+- **Language Modeling (Mask Filling)**
 ```python
 from hezar import Model
 
 roberta_mlm = Model.load("hezarai/roberta-fa-mlm")
 inputs = ["سلام بچه ها حالتون <mask>"]
-outputs = roberta_mlm.predict(inputs)
+outputs = roberta_mlm.predict(inputs, top_k=1)
 print(outputs)
 ```
 ```
-{'filled_texts': ['سلام بچه ها حالتون چطوره'], 'filled_tokens': [' چطوره']}
+[[{'token': 'چطوره', 'sequence': 'سلام بچه ها حالتون چطوره', 'token_id': 34505, 'score': 0.2230483442544937}]]
 ```
 - **Speech Recognition**
 ```python

--- a/docs/get_started/quick_tour.md
+++ b/docs/get_started/quick_tour.md
@@ -33,8 +33,8 @@ print(f"POS: {pos_outputs}")
 print(f"NER: {ner_outputs}")
 ```
 ```
-POS: [[{'token': 'شرکت', 'tag': 'Ne'}, {'token': 'هوش', 'tag': 'Ne'}, {'token': 'مصنوعی', 'tag': 'AJe'}, {'token': 'هزار', 'tag': 'NUM'}]]
-NER: [[{'token': 'شرکت', 'tag': 'B-org'}, {'token': 'هوش', 'tag': 'I-org'}, {'token': 'مصنوعی', 'tag': 'I-org'}, {'token': 'هزار', 'tag': 'I-org'}]]
+POS: [[{'token': 'شرکت', 'label': 'Ne'}, {'token': 'هوش', 'label': 'Ne'}, {'token': 'مصنوعی', 'label': 'AJe'}, {'token': 'هزار', 'label': 'NUM'}]]
+NER: [[{'token': 'شرکت', 'label': 'B-org'}, {'token': 'هوش', 'label': 'I-org'}, {'token': 'مصنوعی', 'label': 'I-org'}, {'token': 'هزار', 'label': 'I-org'}]]
 ```
 - **Language Modeling (Mask Filling)**
 ```python

--- a/docs/get_started/quick_tour.md
+++ b/docs/get_started/quick_tour.md
@@ -63,7 +63,7 @@ print(transcripts)
 ```python
 from hezar import Model
 # OCR with TrOCR
-model = Model.load("hezarai/trocr-base-fa-v1")
+model = Model.load("hezarai/trocr-base-fa-v2")
 texts = model.predict(["examples/assets/ocr_example.jpg"])
 print(f"TrOCR Output: {texts}")
 
@@ -73,8 +73,8 @@ texts = model.predict("examples/assets/ocr_example.jpg")
 print(f"CRNN Output: {texts}")
 ```
 ```
-TrOCR Output: {'texts': [' چه میشه کرد، باید صبر کنیم']}
-CRNN Output: {'texts': ['چه میشه کرد، باید صبر کنیم']}
+TrOCR Output: [{'text': 'چه میشه کرد، باید صبر کنیم'}]
+CRNN Output: [{'text': 'چه میشه کرد، باید صبر کنیم'}]
 ```
 ![](https://raw.githubusercontent.com/hezarai/hezar/main/examples/assets/ocr_example.jpg)
 
@@ -87,7 +87,7 @@ plate_text = model.predict("assets/license_plate_ocr_example.jpg")
 print(plate_text)  # Persian text of mixed numbers and characters might not show correctly in the console
 ```
 ```
-{'texts': ['۵۷س۷۷۹۷۷']}
+[{'text': '۵۷س۷۷۹۷۷'}]
 ```
 ![](https://raw.githubusercontent.com/hezarai/hezar/main/examples/assets/license_plate_ocr_example.jpg)
 
@@ -100,7 +100,7 @@ texts = model.predict("examples/assets/image_captioning_example.jpg")
 print(texts)
 ```
 ```
-{'texts': ['سگی با توپ تنیس در دهانش می دود.']}
+[{'text': 'سگی با توپ تنیس در دهانش می دود.'}]
 ```
 ![](https://raw.githubusercontent.com/hezarai/hezar/main/examples/assets/image_captioning_example.jpg)
 

--- a/docs/get_started/quick_tour.md
+++ b/docs/get_started/quick_tour.md
@@ -18,7 +18,7 @@ outputs = model.predict(example)
 print(outputs)
 ```
 ```
-{'labels': ['positive'], 'probs': [0.812910258769989]}
+[[{'label': 'positive', 'score': 0.812910258769989}]]
 ```
 - **Sequence Labeling (POS, NER, etc.)**
 ```python

--- a/docs/get_started/quick_tour.md
+++ b/docs/get_started/quick_tour.md
@@ -57,7 +57,7 @@ transcripts = whisper.predict("examples/assets/speech_example.mp3")
 print(transcripts)
 ```
 ```
-{'transcripts': ['و این تنها محدود به محیط کار نیست']}
+[{'text': 'و این تنها محدود به محیط کار نیست'}]
 ```
 - **Image to Text (OCR)**
 ```python

--- a/docs/get_started/quick_tour.md
+++ b/docs/get_started/quick_tour.md
@@ -36,17 +36,17 @@ print(f"NER: {ner_outputs}")
 POS: [[{'token': 'شرکت', 'tag': 'Ne'}, {'token': 'هوش', 'tag': 'Ne'}, {'token': 'مصنوعی', 'tag': 'AJe'}, {'token': 'هزار', 'tag': 'NUM'}]]
 NER: [[{'token': 'شرکت', 'tag': 'B-org'}, {'token': 'هوش', 'tag': 'I-org'}, {'token': 'مصنوعی', 'tag': 'I-org'}, {'token': 'هزار', 'tag': 'I-org'}]]
 ```
-- **Language Modeling**
+- **Language Modeling (Mask Filling)**
 ```python
 from hezar import Model
 
 roberta_mlm = Model.load("hezarai/roberta-fa-mlm")
 inputs = ["سلام بچه ها حالتون <mask>"]
-outputs = roberta_mlm.predict(inputs)
+outputs = roberta_mlm.predict(inputs, top_k=1)
 print(outputs)
 ```
 ```
-{'filled_texts': ['سلام بچه ها حالتون چطوره'], 'filled_tokens': [' چطوره']}
+[[{'token': 'چطوره', 'sequence': 'سلام بچه ها حالتون چطوره', 'token_id': 34505, 'score': 0.2230483442544937}]]
 ```
 - **Speech Recognition**
 ```python

--- a/examples/inference/language_modeling_examlple.py
+++ b/examples/inference/language_modeling_examlple.py
@@ -4,5 +4,5 @@ from hezar import Model
 path = "hezarai/roberta-fa-mlm"
 text = ["سلام بچه ها حالتون <mask>"]
 model = Model.load(path)
-outputs = model.predict(text)
+outputs = model.predict(text, top_k=1, device="cuda")
 print(outputs)

--- a/examples/inference/license_plate_ocr_example.py
+++ b/examples/inference/license_plate_ocr_example.py
@@ -1,0 +1,6 @@
+from hezar import Model
+
+
+model = Model.load("hezarai/crnn-fa-64x256-license-plate-recognition")  # CRNN
+text = model.predict("../assets/license_plate_ocr_example.jpg")
+print(text)

--- a/examples/inference/ner_tagging_example.py
+++ b/examples/inference/ner_tagging_example.py
@@ -3,5 +3,5 @@ from hezar import Model
 
 model = Model.load("hezarai/bert-fa-pos-lscp-500k")
 inputs = ["سلام بر فارسی زبانان شریف"]
-outputs = model.predict(inputs)
+outputs = model.predict(inputs, return_scores=True, return_offsets=True)
 print(outputs)

--- a/examples/inference/ner_tagging_example.py
+++ b/examples/inference/ner_tagging_example.py
@@ -1,8 +1,7 @@
 from hezar import Model
 
 
-hub_path = "hezarai/bert-fa-pos-lscp-500k"
-model = Model.load(hub_path)
+model = Model.load("hezarai/bert-fa-pos-lscp-500k")
 inputs = ["سلام بر فارسی زبانان شریف"]
 outputs = model.predict(inputs)
 print(outputs)

--- a/examples/inference/pos_tagging_example.py
+++ b/examples/inference/pos_tagging_example.py
@@ -1,0 +1,6 @@
+from hezar import Model
+
+model = Model.load("hezarai/bert-fa-ner-arman")
+inputs = ["شرکت هوش مصنوعی هزار"]
+outputs = model.predict(inputs)
+print(outputs)

--- a/examples/inference/text_classification_example.py
+++ b/examples/inference/text_classification_example.py
@@ -1,8 +1,6 @@
 from hezar import Model
 
-
-hub_path = "hezarai/distilbert-fa-sentiment-dksf"
-model = Model.load(hub_path, device="cpu")
-inputs = ["کتابخانه هزار، بهترین کتابخانه هوش مصنوعیه"]
-model_outputs = model.predict(inputs)
-print(model_outputs)
+example = ["هزار، کتابخانه‌ای کامل برای به کارگیری آسان هوش مصنوعی"]
+model = Model.load("hezarai/distilbert-fa-sentiment-dksf")
+outputs = model.predict(example)
+print(outputs)

--- a/hezar/models/image2text/beit_roberta/beit_roberta_image2text.py
+++ b/hezar/models/image2text/beit_roberta/beit_roberta_image2text.py
@@ -93,4 +93,5 @@ class BeitRobertaImage2Text(Model):
     def post_process(self, model_outputs, **kwargs):
         tokenizer = self.preprocessor[self.tokenizer_name]
         decoded_outputs = tokenizer.decode(model_outputs.cpu().numpy().tolist())
-        return Image2TextOutput(texts=decoded_outputs)
+        outputs = [Image2TextOutput(text=text) for text in decoded_outputs]
+        return outputs

--- a/hezar/models/image2text/crnn/crnn_image2text.py
+++ b/hezar/models/image2text/crnn/crnn_image2text.py
@@ -77,15 +77,15 @@ class CRNNImage2Text(Model):
         return processed_outputs
 
     def post_process(self, model_outputs: torch.Tensor, **kwargs):
-        texts = []
+        outputs = []
         generated_ids = model_outputs.cpu().numpy().tolist()
         for decoded_ids in generated_ids:
             chars = [self.config.id2label[id_] for id_ in decoded_ids]
             text = "".join(chars)
             if self.config.reverse_prediction_text:
                 text = text[::-1]
-            texts.append(text)
-        return Image2TextOutput(texts=texts)
+            outputs.append(Image2TextOutput(text=text))
+        return outputs
 
 
 class ConvBlock(nn.Module):

--- a/hezar/models/image2text/trocr/trocr_image2text.py
+++ b/hezar/models/image2text/trocr/trocr_image2text.py
@@ -93,4 +93,5 @@ class TrOCRImage2Text(Model):
     def post_process(self, model_outputs, **kwargs):
         tokenizer = self.preprocessor[self.tokenizer_name]
         decoded_outputs = tokenizer.decode(model_outputs.cpu().numpy().tolist())
-        return Image2TextOutput(texts=decoded_outputs)
+        outputs = [Image2TextOutput(text=text) for text in decoded_outputs]
+        return outputs

--- a/hezar/models/image2text/vit_gpt2/vit_gpt2_image2text.py
+++ b/hezar/models/image2text/vit_gpt2/vit_gpt2_image2text.py
@@ -93,4 +93,5 @@ class ViTGPT2Image2Text(Model):
     def post_process(self, model_outputs, **kwargs):
         tokenizer = self.preprocessor[self.tokenizer_name]
         decoded_outputs = tokenizer.decode(model_outputs.cpu().numpy().tolist())
-        return Image2TextOutput(texts=decoded_outputs)
+        outputs = [Image2TextOutput(text=text) for text in decoded_outputs]
+        return outputs

--- a/hezar/models/image2text/vit_roberta/vit_roberta_image2text.py
+++ b/hezar/models/image2text/vit_roberta/vit_roberta_image2text.py
@@ -95,4 +95,5 @@ class ViTRobertaImage2Text(Model):
     def post_process(self, model_outputs, **kwargs):
         tokenizer = self.preprocessor[self.tokenizer_name]
         decoded_outputs = tokenizer.decode(model_outputs.cpu().numpy().tolist())
-        return Image2TextOutput(texts=decoded_outputs)
+        outputs = [Image2TextOutput(text=text) for text in decoded_outputs]
+        return outputs

--- a/hezar/models/language_modeling/bert/bert_lm.py
+++ b/hezar/models/language_modeling/bert/bert_lm.py
@@ -82,27 +82,39 @@ class BertLM(Model):
         inputs = tokenizer(inputs, return_tensors="pt", device=self.device)
         return inputs
 
-    def post_process(self, model_outputs, **kwargs):
-        output_logits = model_outputs.get("logits", None)
-        token_ids = model_outputs.get("token_ids", None)
+    def post_process(self, model_outputs: dict, top_k=1):
+        output_logits = model_outputs.get("logits")
+        token_ids = model_outputs.get("token_ids")
 
         tokenizer = self.preprocessor[self.tokenizer_name]
+        mask_token_id = tokenizer.mask_token_id
 
-        filled_token_ids = token_ids.cpu().numpy().copy()
-        fill_tokens = []
+        unfilled_token_ids = token_ids.cpu().numpy().copy()
+        outputs = []
         for batch_i, logits in enumerate(output_logits):
-            masked_index = torch.nonzero(token_ids[batch_i] == tokenizer.mask_token_id, as_tuple=False).flatten()  # noqa
+            masked_index = torch.nonzero(token_ids[batch_i] == mask_token_id, as_tuple=False).flatten()  # noqa
             if len(masked_index) > 1:
                 raise ValueError(
                     f"Can't handle multiple `{tokenizer.mask_token}` tokens in the input for {self.__class__.__name__}!"
                 )
-            fill_token_id = logits[masked_index].argmax().item()
-            filled_token_ids[batch_i, masked_index.item()] = fill_token_id
-            fill_tokens.append(tokenizer.decode([fill_token_id])[0])
+            logits = logits[masked_index]
+            probs = logits.softmax(dim=-1)
+            probs, top_fill_token_ids = probs.topk(top_k)
+            if top_k != 1:
+                probs = probs.squeeze()
+                top_fill_token_ids = top_fill_token_ids.squeeze()
 
-        outputs = LanguageModelingOutput(
-            filled_texts=tokenizer.decode(filled_token_ids),
-            filled_tokens=fill_tokens,
-        )
-
+            row = []
+            for i, (prob, token_id) in enumerate(zip(probs, top_fill_token_ids)):
+                candidate = unfilled_token_ids[batch_i].copy()
+                candidate[masked_index.item()] = token_id
+                row.append(
+                    LanguageModelingOutput(
+                        token=tokenizer.decode([token_id.item()])[0].strip(),
+                        sequence=tokenizer.decode(candidate.tolist())[0],
+                        token_id=token_id.item(),
+                        score=prob.item(),
+                    )
+                )
+            outputs.append(row)
         return outputs

--- a/hezar/models/language_modeling/roberta/roberta_lm.py
+++ b/hezar/models/language_modeling/roberta/roberta_lm.py
@@ -81,29 +81,39 @@ class RobertaLM(Model):
         inputs = tokenizer(inputs, return_tensors="pt", device=self.device)
         return inputs
 
-    def post_process(self, model_outputs, top_k=5):
+    def post_process(self, model_outputs: dict, top_k=1):
         output_logits = model_outputs.get("logits")
         token_ids = model_outputs.get("token_ids")
 
         tokenizer = self.preprocessor[self.tokenizer_name]
+        mask_token_id = tokenizer.mask_token_id
 
-        filled_token_ids = token_ids.cpu().numpy().copy()
-        fill_tokens = []
+        unfilled_token_ids = token_ids.cpu().numpy().copy()
+        outputs = []
         for batch_i, logits in enumerate(output_logits):
-            masked_index = torch.nonzero(
-                token_ids[batch_i] == tokenizer.mask_token_id, as_tuple=False
-            ).flatten()  # noqa
+            masked_index = torch.nonzero(token_ids[batch_i] == mask_token_id, as_tuple=False).flatten()  # noqa
             if len(masked_index) > 1:
                 raise ValueError(
                     f"Can't handle multiple `{tokenizer.mask_token}` tokens in the input for {self.__class__.__name__}!"
                 )
-            fill_token_id = logits[masked_index].argmax().item()
-            filled_token_ids[batch_i, masked_index.item()] = fill_token_id
-            fill_tokens.append(tokenizer.decode([fill_token_id])[0])
+            logits = logits[masked_index]
+            probs = logits.softmax(dim=-1)
+            probs, top_fill_token_ids = probs.topk(top_k)
+            if top_k != 1:
+                probs = probs.squeeze()
+                top_fill_token_ids = top_fill_token_ids.squeeze()
 
-        outputs = LanguageModelingOutput(
-            filled_texts=tokenizer.decode(filled_token_ids),
-            filled_tokens=fill_tokens,
-        )
-
+            row = []
+            for i, (prob, token_id) in enumerate(zip(probs, top_fill_token_ids)):
+                candidate = unfilled_token_ids[batch_i].copy()
+                candidate[masked_index.item()] = token_id
+                row.append(
+                    LanguageModelingOutput(
+                        token=tokenizer.decode([token_id.item()])[0].strip(),
+                        sequence=tokenizer.decode(candidate.tolist())[0],
+                        token_id=token_id.item(),
+                        score=prob.item(),
+                    )
+                )
+            outputs.append(row)
         return outputs

--- a/hezar/models/model_outputs.py
+++ b/hezar/models/model_outputs.py
@@ -62,9 +62,11 @@ class TextClassificationOutput(ModelOutput):
 
 @dataclass(repr=False)
 class SequenceLabelingOutput(ModelOutput):
-    tokens: Optional[List[List[str]]] = None
-    tags: Optional[List[List[str]]] = None
-    probs: Optional[List[List[float]]] = None
+    token: Optional[List[List[str]]] = None
+    label: Optional[List[List[str]]] = None
+    start: Optional[int] = None
+    end: Optional[int] = None
+    score: Optional[List[List[float]]] = None
 
 
 @dataclass(repr=False)

--- a/hezar/models/model_outputs.py
+++ b/hezar/models/model_outputs.py
@@ -2,7 +2,6 @@
 Define all model outputs here
 """
 from dataclasses import asdict, dataclass
-from pprint import pformat
 from typing import List, Optional
 
 
@@ -18,7 +17,10 @@ class ModelOutput:
         return asdict(self)
 
     def __str__(self):
-        return pformat(self.dict())
+        return str(self.dict())
+
+    def __repr__(self):
+        return str(self)
 
     def __getitem__(self, item):
         try:
@@ -42,35 +44,37 @@ class ModelOutput:
         return self.dict().items()
 
 
-@dataclass
+@dataclass(repr=False)
 class LanguageModelingOutput(ModelOutput):
-    filled_texts: Optional[List[str]] = None
-    filled_tokens: Optional[List[str]] = None
+    token: Optional[int] = None
+    sequence: Optional[str] = None
+    token_id: Optional[str] = None
+    score: Optional[float] = None
 
 
-@dataclass
+@dataclass(repr=False)
 class TextClassificationOutput(ModelOutput):
-    labels: Optional[List[str]] = None
-    probs: Optional[List[float]] = None
+    label: Optional[List[str]] = None
+    prob: Optional[List[float]] = None
 
 
-@dataclass
+@dataclass(repr=False)
 class SequenceLabelingOutput(ModelOutput):
     tokens: Optional[List[List[str]]] = None
     tags: Optional[List[List[str]]] = None
     probs: Optional[List[List[float]]] = None
 
 
-@dataclass
+@dataclass(repr=False)
 class TextGenerationOutput(ModelOutput):
-    generated_texts: Optional[List[str]] = None
+    generated_text: Optional[List[str]] = None
 
 
-@dataclass
+@dataclass(repr=False)
 class SpeechRecognitionOutput(ModelOutput):
-    transcripts: Optional[List[str]] = None
+    transcript: Optional[List[str]] = None
 
 
-@dataclass
+@dataclass(repr=False)
 class Image2TextOutput(ModelOutput):
-    texts: Optional[List[str]] = None
+    text: Optional[List[str]] = None

--- a/hezar/models/model_outputs.py
+++ b/hezar/models/model_outputs.py
@@ -2,7 +2,7 @@
 Define all model outputs here
 """
 from dataclasses import asdict, dataclass
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -17,7 +17,7 @@ class ModelOutput:
         return asdict(self)
 
     def __str__(self):
-        return str(self.dict())
+        return str({k: v for k, v in self.dict().items() if v is not None})
 
     def __repr__(self):
         return str(self)
@@ -72,7 +72,8 @@ class TextGenerationOutput(ModelOutput):
 
 @dataclass(repr=False)
 class SpeechRecognitionOutput(ModelOutput):
-    transcript: Optional[str] = None
+    text: Optional[str] = None
+    chunks: Optional[List[Dict]] = None
 
 
 @dataclass(repr=False)

--- a/hezar/models/model_outputs.py
+++ b/hezar/models/model_outputs.py
@@ -8,7 +8,9 @@ from typing import Dict, List, Optional
 @dataclass
 class ModelOutput:
     """
-    Base class for all model outputs (named based on tasks)
+    Base class for all models' prediction outputs (`model.predict()`/`model.post_process()` outputs).
+
+    Note that prediction outputs must all be a list of `ModelOutput` objects since we consider only batch inferences.
 
     The helper functions in the class enable it to be treated as a mapping or a dict object.
     """
@@ -67,7 +69,7 @@ class SequenceLabelingOutput(ModelOutput):
 
 @dataclass(repr=False)
 class TextGenerationOutput(ModelOutput):
-    generated_text: Optional[str] = None
+    text: Optional[str] = None
 
 
 @dataclass(repr=False)

--- a/hezar/models/model_outputs.py
+++ b/hezar/models/model_outputs.py
@@ -54,8 +54,8 @@ class LanguageModelingOutput(ModelOutput):
 
 @dataclass(repr=False)
 class TextClassificationOutput(ModelOutput):
-    label: Optional[List[str]] = None
-    prob: Optional[List[float]] = None
+    label: Optional[str] = None
+    score: Optional[float] = None
 
 
 @dataclass(repr=False)

--- a/hezar/models/model_outputs.py
+++ b/hezar/models/model_outputs.py
@@ -67,14 +67,14 @@ class SequenceLabelingOutput(ModelOutput):
 
 @dataclass(repr=False)
 class TextGenerationOutput(ModelOutput):
-    generated_text: Optional[List[str]] = None
+    generated_text: Optional[str] = None
 
 
 @dataclass(repr=False)
 class SpeechRecognitionOutput(ModelOutput):
-    transcript: Optional[List[str]] = None
+    transcript: Optional[str] = None
 
 
 @dataclass(repr=False)
 class Image2TextOutput(ModelOutput):
-    text: Optional[List[str]] = None
+    text: Optional[str] = None

--- a/hezar/models/sequence_labeling/bert/bert_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/bert/bert_sequence_labeling.py
@@ -10,6 +10,7 @@ from ....constants import Backends
 from ....registry import register_model
 from ....utils import is_backend_available
 from ...model import Model
+from ...model_outputs import SequenceLabelingOutput
 from .bert_sequence_labeling_config import BertSequenceLabelingConfig
 
 
@@ -81,6 +82,7 @@ class BertSequenceLabeling(Model):
             "hidden_states": lm_outputs.hidden_states,
             "attentions": lm_outputs.attentions,
             "tokens": kwargs.get("tokens", None),
+            "offsets": kwargs.get("offsets_mapping", None)
         }
         return outputs
 
@@ -100,6 +102,7 @@ class BertSequenceLabeling(Model):
             inputs,
             return_word_ids=True,
             return_tokens=True,
+            return_offsets_mapping=True,
             padding=True,
             truncation=True,
             return_tensors="pt",
@@ -107,16 +110,29 @@ class BertSequenceLabeling(Model):
         )
         return inputs
 
-    def post_process(self, model_outputs, **kwargs):
-        logits = model_outputs["logits"]
+    def post_process(
+        self,
+        model_outputs: Dict[str, torch.Tensor],
+        return_offsets: bool = False,
+        return_scores: bool = False,
+    ):
+        logits = model_outputs["logits"].softmax(2)
         tokens = model_outputs["tokens"]
-        predictions = logits.argmax(2).cpu()
+        offsets = model_outputs["offsets"]
+        probs, predictions = logits.max(2)
         predictions = [[self.config.id2label[p.item()] for p in prediction] for prediction in predictions]
         outputs = []
-        for tokens_list, prediction in zip(tokens, predictions):
+        for tokens_list, prediction, probs_, offsets_mapping in zip(tokens, predictions, probs, offsets):
             results = []
-            for token, tag in zip(tokens_list, prediction):
+            for token, label, prob, offset in zip(tokens_list, prediction, probs_, offsets_mapping):
                 if token not in self.config.prediction_skip_tokens:
-                    results.append({"token": token, "tag": tag})
+                    token_results = {"token": token, "label": label}
+                    if return_scores:
+                        token_results["score"] = prob
+                    if return_offsets:
+                        start, end = offset
+                        token_results["start"] = start
+                        token_results["end"] = end
+                    results.append(SequenceLabelingOutput(**token_results))
             outputs.append(results)
         return outputs

--- a/hezar/models/sequence_labeling/bert/bert_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/bert/bert_sequence_labeling.py
@@ -128,7 +128,7 @@ class BertSequenceLabeling(Model):
                 if token not in self.config.prediction_skip_tokens:
                     token_results = {"token": token, "label": label}
                     if return_scores:
-                        token_results["score"] = prob
+                        token_results["score"] = prob.item()
                     if return_offsets:
                         start, end = offset
                         token_results["start"] = start

--- a/hezar/models/sequence_labeling/distilbert/distilbert_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/distilbert/distilbert_sequence_labeling.py
@@ -124,7 +124,7 @@ class DistilBertSequenceLabeling(Model):
                 if token not in self.config.prediction_skip_tokens:
                     token_results = {"token": token, "label": label}
                     if return_scores:
-                        token_results["score"] = prob
+                        token_results["score"] = prob.item()
                     if return_offsets:
                         start, end = offset
                         token_results["start"] = start

--- a/hezar/models/sequence_labeling/distilbert/distilbert_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/distilbert/distilbert_sequence_labeling.py
@@ -10,6 +10,7 @@ from ....constants import Backends
 from ....registry import register_model
 from ....utils import is_backend_available
 from ...model import Model
+from ...model_outputs import SequenceLabelingOutput
 from .distilbert_sequence_labeling_config import DistilBertSequenceLabelingConfig
 
 
@@ -77,6 +78,7 @@ class DistilBertSequenceLabeling(Model):
             "hidden_states": lm_outputs.hidden_states,
             "attentions": lm_outputs.attentions,
             "tokens": kwargs.get("tokens", None),
+            "offsets": kwargs.get("offsets_mapping", None)
         }
         return outputs
 
@@ -96,6 +98,7 @@ class DistilBertSequenceLabeling(Model):
             inputs,
             return_word_ids=True,
             return_tokens=True,
+            return_offsets_mapping=True,
             padding=True,
             truncation=True,
             return_tensors="pt",
@@ -103,16 +106,29 @@ class DistilBertSequenceLabeling(Model):
         )
         return inputs
 
-    def post_process(self, model_outputs, **kwargs):
-        logits = model_outputs["logits"]
+    def post_process(
+        self,
+        model_outputs: Dict[str, torch.Tensor],
+        return_offsets: bool = False,
+        return_scores: bool = False,
+    ):
+        logits = model_outputs["logits"].softmax(2)
         tokens = model_outputs["tokens"]
-        predictions = logits.argmax(2).cpu()
+        offsets = model_outputs["offsets"]
+        probs, predictions = logits.max(2)
         predictions = [[self.config.id2label[p.item()] for p in prediction] for prediction in predictions]
         outputs = []
-        for tokens_list, prediction in zip(tokens, predictions):
+        for tokens_list, prediction, probs_, offsets_mapping in zip(tokens, predictions, probs, offsets):
             results = []
-            for token, tag in zip(tokens_list, prediction):
+            for token, label, prob, offset in zip(tokens_list, prediction, probs_, offsets_mapping):
                 if token not in self.config.prediction_skip_tokens:
-                    results.append({"token": token, "tag": tag})
+                    token_results = {"token": token, "label": label}
+                    if return_scores:
+                        token_results["score"] = prob
+                    if return_offsets:
+                        start, end = offset
+                        token_results["start"] = start
+                        token_results["end"] = end
+                    results.append(SequenceLabelingOutput(**token_results))
             outputs.append(results)
         return outputs

--- a/hezar/models/sequence_labeling/roberta/roberta_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/roberta/roberta_sequence_labeling.py
@@ -127,7 +127,7 @@ class RobertaSequenceLabeling(Model):
                 if token not in self.config.prediction_skip_tokens:
                     token_results = {"token": token, "label": label}
                     if return_scores:
-                        token_results["score"] = prob
+                        token_results["score"] = prob.item()
                     if return_offsets:
                         start, end = offset
                         token_results["start"] = start

--- a/hezar/models/speech_recognition/whisper/whisper_speech_recognition.py
+++ b/hezar/models/speech_recognition/whisper/whisper_speech_recognition.py
@@ -166,4 +166,5 @@ class WhisperSpeechRecognition(Model):
     def post_process(self, model_outputs, **kwargs):
         tokenizer = self.preprocessor[self.tokenizer_name]
         transcripts = tokenizer.decode(model_outputs, decode_with_timestamps=True, skip_special_tokens=True)
-        return SpeechRecognitionOutput(transcripts=transcripts)
+        outputs = [SpeechRecognitionOutput(text=transcript) for transcript in transcripts]
+        return outputs

--- a/hezar/models/text_classification/bert/bert_text_classification.py
+++ b/hezar/models/text_classification/bert/bert_text_classification.py
@@ -10,6 +10,7 @@ from ....constants import Backends
 from ....registry import register_model
 from ....utils import is_backend_available
 from ...model import Model
+from ...model_outputs import TextClassificationOutput
 from .bert_text_classification_config import BertTextClassificationConfig
 
 
@@ -113,24 +114,18 @@ class BertTextClassification(Model):
         inputs = tokenizer(inputs, return_tensors="pt", device=self.device)
         return inputs
 
-    def post_process(self, model_outputs, return_all_scores=False, **kwargs) -> Dict:
-        logits = model_outputs["logits"]
-        if return_all_scores:
-            predictions = logits
-            predictions_probs = logits.softmax(1)
-            outputs = []
-            for sample_index in range(predictions.shape[0]):
-                sample_outputs = []
-                for label_index, score in enumerate(predictions_probs[sample_index]):
-                    label = self.config.id2label[label_index]
-                    sample_outputs.append({"label": label, "score": score.item()})
-                outputs.append(sample_outputs)
-        else:
-            predictions = logits.argmax(1)
-            predictions_probs = logits.softmax(1).max(1)
-            outputs = {"labels": [], "probs": []}
-            for prediction, prob in zip(predictions, predictions_probs):
-                label = self.config.id2label[prediction.item()]
-                outputs["labels"].append(label)
-                outputs["probs"].append(prob.item())
+    def post_process(self, model_outputs: dict, top_k=1):
+        output_logits = model_outputs["logits"]
+        outputs = []
+        for logits in output_logits:
+            probs = logits.softmax(dim=-1)
+            scores, label_ids = probs.sort(descending=True)
+            row = []
+            for i, (score, label_id) in enumerate(zip(scores, label_ids)):
+                if i == top_k:
+                    break
+                label_str = self.config.id2label[label_id.item()]
+                score = score.item()
+                row.append(TextClassificationOutput(label=label_str, score=score))
+            outputs.append(row)
         return outputs

--- a/hezar/models/text_classification/roberta/roberta_text_classification.py
+++ b/hezar/models/text_classification/roberta/roberta_text_classification.py
@@ -1,7 +1,7 @@
 """
 A RoBERTa Language Model (HuggingFace Transformers) wrapped by a Hezar Model class
 """
-from typing import Dict, List, Union
+from typing import List, Union
 
 import torch
 from torch import nn, tanh
@@ -10,6 +10,7 @@ from ....constants import Backends
 from ....registry import register_model
 from ....utils import is_backend_available
 from ...model import Model
+from ...model_outputs import TextClassificationOutput
 from .roberta_text_classification_config import RobertaTextClassificationConfig
 
 
@@ -97,26 +98,20 @@ class RobertaTextClassification(Model):
         inputs = tokenizer(inputs, return_tensors="pt", device=self.device)
         return inputs
 
-    def post_process(self, model_outputs, return_all_scores=False, **kwargs) -> Dict:
-        logits = model_outputs["logits"]
-        if return_all_scores:
-            predictions = logits
-            predictions_probs = logits.softmax(1)
-            outputs = []
-            for sample_index in range(predictions.shape[0]):
-                sample_outputs = []
-                for label_index, score in enumerate(predictions_probs[sample_index]):
-                    label = self.config.id2label[label_index]
-                    sample_outputs.append({"label": label, "score": score.item()})
-                outputs.append(sample_outputs)
-        else:
-            predictions = logits.argmax(1)
-            predictions_probs = logits.softmax(1).max(1)
-            outputs = {"labels": [], "probs": []}
-            for prediction, prob in zip(predictions, predictions_probs):
-                label = self.config.id2label[prediction.item()]
-                outputs["labels"].append(label)
-                outputs["probs"].append(prob.item())
+    def post_process(self, model_outputs: dict, top_k=1):
+        output_logits = model_outputs["logits"]
+        outputs = []
+        for logits in output_logits:
+            probs = logits.softmax(dim=-1)
+            scores, label_ids = probs.sort(descending=True)
+            row = []
+            for i, (score, label_id) in enumerate(zip(scores, label_ids)):
+                if i == top_k:
+                    break
+                label_str = self.config.id2label[label_id.item()]
+                score = score.item()
+                row.append(TextClassificationOutput(label=label_str, score=score))
+            outputs.append(row)
         return outputs
 
 

--- a/hezar/models/text_generation/gpt2/gpt2_text_generation.py
+++ b/hezar/models/text_generation/gpt2/gpt2_text_generation.py
@@ -6,6 +6,7 @@ from ....constants import Backends
 from ....registry import register_model
 from ....utils import is_backend_available
 from ...model import Model
+from ...model_outputs import TextGenerationOutput
 from .gpt2_text_generation_config import GPT2TextGenerationConfig
 
 
@@ -87,4 +88,5 @@ class GPT2TextGeneration(Model):
     def post_process(self, generated_ids: torch.Tensor):
         tokenizer = self.preprocessor[self.tokenizer_name]
         decoded_outputs = tokenizer.decode(generated_ids.cpu().numpy().tolist())
-        return decoded_outputs
+        outputs = [TextGenerationOutput(text=text) for text in decoded_outputs]
+        return outputs


### PR DESCRIPTION
# What does this PR do?
In this PR, all model predictions are refactored in order to:
- Enhance readability and follow a common practice
- Match the HF Inference API format for pipelines

This PR was mainly dedicated to #56 . 
All models have been tested carefully.
All the effected docs have been updated.
Only `models` were effected by this PR. 

**Note:** These changes can be considered backward incompatible for users who have built upon previous model output formats!