### PR TITLE
Optimize imports by disallowing direct imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Let's walk you through some examples!
 
 - **Text Classification (sentiment analysis, categorization, etc)**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 example = ["هزار، کتابخانه‌ای کامل برای به کارگیری آسان هوش مصنوعی"]
 model = Model.load("hezarai/bert-fa-sentiment-dksf")
@@ -67,7 +67,7 @@ print(outputs)
 ```
 - **Sequence Labeling (POS, NER, etc.)**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 pos_model = Model.load("hezarai/bert-fa-pos-lscp-500k")  # Part-of-speech
 ner_model = Model.load("hezarai/bert-fa-ner-arman")  # Named entity recognition
@@ -83,7 +83,7 @@ NER: [[{'token': 'شرکت', 'label': 'B-org'}, {'token': 'هوش', 'label': 'I-
 ```
 - **Language Modeling (Mask Filling)**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 roberta_mlm = Model.load("hezarai/roberta-fa-mlm")
 inputs = ["سلام بچه ها حالتون <mask>"]
@@ -95,7 +95,7 @@ print(outputs)
 ```
 - **Speech Recognition**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 whisper = Model.load("hezarai/whisper-small-fa")
 transcripts = whisper.predict("examples/assets/speech_example.mp3")
@@ -106,7 +106,7 @@ print(transcripts)
 ```
 - **Image to Text (OCR)**
 ```python
-from hezar import Model
+from hezar.models import Model
 # OCR with TrOCR
 model = Model.load("hezarai/trocr-base-fa-v2")
 texts = model.predict(["examples/assets/ocr_example.jpg"])
@@ -125,7 +125,7 @@ CRNN Output: [{'text': 'چه میشه کرد، باید صبر کنیم'}]
 
 - **Image to Text (License Plate Recognition)**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 model = Model.load("hezarai/crnn-fa-64x256-license-plate-recognition")
 plate_text = model.predict("assets/license_plate_ocr_example.jpg")
@@ -138,7 +138,7 @@ print(plate_text)  # Persian text of mixed numbers and characters might not show
 
 - **Image to Text (Image Captioning)**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 model = Model.load("hezarai/vit-roberta-fa-image-captioning-flickr30k")
 texts = model.predict("examples/assets/image_captioning_example.jpg")
@@ -153,7 +153,7 @@ We constantly keep working on adding and training new models and this section wi
 ### Word Embeddings
 - **FastText**
 ```python
-from hezar import Embedding
+from hezar.embeddings import Embedding
 
 fasttext = Embedding.load("hezarai/fasttext-fa-300")
 most_similar = fasttext.most_similar("هزار")
@@ -168,7 +168,7 @@ print(most_similar)
 ```
 - **Word2Vec (Skip-gram)**
 ```python
-from hezar import Embedding
+from hezar.embeddings import Embedding
 
 word2vec = Embedding.load("hezarai/word2vec-skipgram-fa-wikipedia")
 most_similar = word2vec.most_similar("هزار")
@@ -183,7 +183,7 @@ print(most_similar)
 ```
 - **Word2Vec (CBOW)**
 ```python
-from hezar import Embedding
+from hezar.embeddings import Embedding
 
 word2vec = Embedding.load("hezarai/word2vec-cbow-fa-wikipedia")
 most_similar = word2vec.most_similar("هزار")
@@ -199,7 +199,7 @@ print(most_similar)
 ### Datasets
 You can load any of the datasets on the [Hub](https://huggingface.co/hezarai) like below:
 ```python
-from hezar import Dataset
+from hezar.data import Dataset
 
 sentiment_dataset = Dataset.load("hezarai/sentiment-dksf")  # A TextClassificationDataset instance
 lscp_dataset = Dataset.load("hezarai/lscp-pos-500k")  # A SequenceLabelingDataset instance
@@ -208,15 +208,12 @@ xlsum_dataset = Dataset.load("hezarai/xlsum-fa")  # A TextSummarizationDataset i
 ```
 ### Training
 Hezar makes it super easy to train models using out-of-the-box models and datasets provided in the library.
+
 ```python
-from hezar import (
-    BertSequenceLabeling,
-    BertSequenceLabelingConfig,
-    TrainerConfig,
-    Trainer,
-    Dataset,
-    Preprocessor,
-)
+from hezar.models import BertSequenceLabeling, BertSequenceLabelingConfig
+from hezar.data import Dataset
+from hezar.trainer import Trainer, TrainerConfig
+from hezar.preprocessors import Preprocessor
 
 base_model_path = "hezarai/bert-base-fa"
 dataset_path = "hezarai/lscp-pos-500k"

--- a/docs/get_started/quick_tour.md
+++ b/docs/get_started/quick_tour.md
@@ -10,7 +10,7 @@ Let's walk you through some examples!
 
 - **Text Classification (sentiment analysis, categorization, etc)**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 example = ["هزار، کتابخانه‌ای کامل برای به کارگیری آسان هوش مصنوعی"]
 model = Model.load("hezarai/bert-fa-sentiment-dksf")
@@ -22,7 +22,7 @@ print(outputs)
 ```
 - **Sequence Labeling (POS, NER, etc.)**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 pos_model = Model.load("hezarai/bert-fa-pos-lscp-500k")  # Part-of-speech
 ner_model = Model.load("hezarai/bert-fa-ner-arman")  # Named entity recognition
@@ -38,7 +38,7 @@ NER: [[{'token': 'شرکت', 'label': 'B-org'}, {'token': 'هوش', 'label': 'I-
 ```
 - **Language Modeling (Mask Filling)**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 roberta_mlm = Model.load("hezarai/roberta-fa-mlm")
 inputs = ["سلام بچه ها حالتون <mask>"]
@@ -50,7 +50,7 @@ print(outputs)
 ```
 - **Speech Recognition**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 whisper = Model.load("hezarai/whisper-small-fa")
 transcripts = whisper.predict("examples/assets/speech_example.mp3")
@@ -61,7 +61,7 @@ print(transcripts)
 ```
 - **Image to Text (OCR)**
 ```python
-from hezar import Model
+from hezar.models import Model
 # OCR with TrOCR
 model = Model.load("hezarai/trocr-base-fa-v2")
 texts = model.predict(["examples/assets/ocr_example.jpg"])
@@ -80,7 +80,7 @@ CRNN Output: [{'text': 'چه میشه کرد، باید صبر کنیم'}]
 
 - **Image to Text (License Plate Recognition)**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 model = Model.load("hezarai/crnn-fa-64x256-license-plate-recognition")
 plate_text = model.predict("assets/license_plate_ocr_example.jpg")
@@ -93,7 +93,7 @@ print(plate_text)  # Persian text of mixed numbers and characters might not show
 
 - **Image to Text (Image Captioning)**
 ```python
-from hezar import Model
+from hezar.models import Model
 
 model = Model.load("hezarai/vit-roberta-fa-image-captioning-flickr30k")
 texts = model.predict("examples/assets/image_captioning_example.jpg")
@@ -108,7 +108,7 @@ We constantly keep working on adding and training new models and this section wi
 ### Word Embeddings
 - **FastText**
 ```python
-from hezar import Embedding
+from hezar.embeddings import Embedding
 
 fasttext = Embedding.load("hezarai/fasttext-fa-300")
 most_similar = fasttext.most_similar("هزار")
@@ -123,7 +123,7 @@ print(most_similar)
 ```
 - **Word2Vec (Skip-gram)**
 ```python
-from hezar import Embedding
+from hezar.embeddings import Embedding
 
 word2vec = Embedding.load("hezarai/word2vec-skipgram-fa-wikipedia")
 most_similar = word2vec.most_similar("هزار")
@@ -138,7 +138,7 @@ print(most_similar)
 ```
 - **Word2Vec (CBOW)**
 ```python
-from hezar import Embedding
+from hezar.embeddings import Embedding
 
 word2vec = Embedding.load("hezarai/word2vec-cbow-fa-wikipedia")
 most_similar = word2vec.most_similar("هزار")
@@ -154,7 +154,7 @@ print(most_similar)
 ### Datasets
 You can load any of the datasets on the [Hub](https://huggingface.co/hezarai) like below:
 ```python
-from hezar import Dataset
+from hezar.data import Dataset
 
 sentiment_dataset = Dataset.load("hezarai/sentiment-dksf")  # A TextClassificationDataset instance
 lscp_dataset = Dataset.load("hezarai/lscp-pos-500k")  # A SequenceLabelingDataset instance
@@ -165,14 +165,10 @@ xlsum_dataset = Dataset.load("hezarai/xlsum-fa")  # A TextSummarizationDataset i
 ### Training
 Hezar makes it super easy to train models using out-of-the-box models and datasets provided in the library.
 ```python
-from hezar import (
-    BertSequenceLabeling,
-    BertSequenceLabelingConfig,
-    Trainer,
-    TrainerConfig,
-    Dataset,
-    Preprocessor,
-)
+from hezar.models import BertSequenceLabeling, BertSequenceLabelingConfig
+from hezar.data import Dataset
+from hezar.trainer import Trainer, TrainerConfig
+from hezar.preprocessors import Preprocessor
 
 base_model_path = "hezarai/bert-base-fa"
 dataset_path = "hezarai/lscp-pos-500k"

--- a/docs/guide/hezar_architecture.md
+++ b/docs/guide/hezar_architecture.md
@@ -34,7 +34,7 @@ Let's assume you want to write a new model class called `AwesomeModel`. The firs
 
 ```python
 from dataclasses import dataclass
-from hezar import ModelConfig, Model
+from hezar.models import ModelConfig, Model
 
 
 @dataclass
@@ -66,28 +66,28 @@ snippets:
 
 ```python
 # Load a model
-from hezar import Model
+from hezar.models import Model
 
 roberta_tc = Model.load("hezarai/roberta-fa-sentiment-dksf")  # roberta_tc is a RobertaTextClassification instance
 bert_pos = Model.load("hezarai/bert-fa-pos-lscp-500k")  # bert_pos is a BertSequenceLabeling instance
 whisper_speech = Model.load("hezarai/whisper-small-fa")  # whisper_speech is a WhisperSpeechRecognition instance
 ...
 # Load a dataset
-from hezar import Dataset
+from hezar.data import Dataset
 
 sentiment_dataset = Dataset.load("hezarai/sentiment-dksf")  # A TextClassificationDataset instance
 lscp_dataset = Dataset.load("hezarai/lscp-pos-500k")  # A SequenceLabelingDataset instance
 xlsum_dataset = Dataset.load("hezarai/xlsum-fa")  # A TextSummarizationDataset instance
 ...
 # Load preprocessors
-from hezar import Preprocessor
+from hezar.preprocessors import Preprocessor
 
 wordpiece = Preprocessor.load("hezarai/bert-base-fa")  # A WordPieceTokenizer instance
 whisper_bpe = Preprocessor.load("hezarai/whisper-small-fa")  # A WhisperBPETokenizer instance
 sp_unigram_bpe = Preprocessor.load("hezarai/t5-base-fa")  # A SentencePieceUnigramTokenizer instance
 ...
 # Load embedding
-from hezar import Embedding
+from hezar.embeddings import Embedding
 
 fasttext = Embedding.load("hezarai/fasttext-fa-300")  # A FastText instance
 word2vec = Embedding.load("hezarai/word2vec-skipgram-fa-wikipedia")  # A Word2Vec instance
@@ -133,7 +133,7 @@ These decorators take two parameters:
 The example below demonstrates registering a model:
 ```python
 ...
-from hezar import Model, ModelConfig, register_model
+from hezar.models import Model, ModelConfig
 
 @dataclass
 class MyBertConfig(ModelConfig):
@@ -178,7 +178,7 @@ print(hezar.list_available_trainers())
 So now it's pretty easy to create modules objects using their `name`! Let's say you want to create a
 BPE tokenizer. You can do it this way:
 ```python
-from hezar import preprocessors_registry
+from hezar.registry import preprocessors_registry
 
 module_cls = preprocessors_registry["bpe_tokenizer"].module_class
 config_cls = preprocessors_registry["bpe_tokenizer"].config_class
@@ -213,7 +213,7 @@ Available builders include:
 
 So why would you need to use builders or registries when you can import everything normally? like below:
 ```python
-from hezar import WhisperSpeechRecognition, WhisperSpeechRecognitionConfig
+from hezar.models import WhisperSpeechRecognition, WhisperSpeechRecognitionConfig
 
 whisper = WhisperSpeechRecognition(WhisperSpeechRecognitionConfig(max_new_tokens=400))
 ```
@@ -276,7 +276,7 @@ More specifically, here's a simple summary of the core modules in Hezar:
 
 
 ## Concept 6: Our Inspirations
-Hezar was built using the best practices we've learned from working with dozens of industry leading open source 
+Hezar was built using the best practices we've learned from working with dozens of industry leading open source
 software in the AI world. Our biggest inspirations are:
 
 - [Transformers](https://github.com/huggingface/transformers) by Hugging Face

--- a/docs/guide/models_advanced.md
+++ b/docs/guide/models_advanced.md
@@ -50,7 +50,7 @@ from dataclasses import dataclass
 
 import torch
 import torch.nn as nn
-from hezar import Model, ModelConfig, register_model
+from hezar.models import Model, ModelConfig, register_model
 
 @dataclass
 class SampleNetConfig(ModelConfig):
@@ -92,7 +92,7 @@ have a name which must be the same as the one in its config under `name` paramet
 
 To see all the available models use:
 ```python
-from hezar import list_available_models
+from hezar.utils import list_available_models
 
 print(list_available_models())
 ```
@@ -102,7 +102,7 @@ The `models_registry` (like all registry containers in Hezar) is a dictionary of
 and config classes. So one can easily build a model with default parameters by its registry key.
 
 ```python
-from hezar import models_registry
+from hezar.registry import models_registry
 
 bert = models_registry["bert"].module_class(models_registry["bert"].config_class())
 ```
@@ -111,19 +111,20 @@ Obviously, this is so ugly and long so lets use the build method `build_model`. 
 - `config`: Optional model config
 - `**kwargs`: Extra config parameters as keyword arguments that overwrites the default config parameters.
 ```python
-from hezar import build_model
+from hezar.builders import build_model
 
 bert = build_model("bert")
 ```
 You can also pass config parameters to the `build_model` method as kwargs to overwrite default config parameters:
 ```python
-from hezar import build_model
+from hezar.builders import build_model
 
 bert = build_model("bert", hidden_size=768)
 ```
 Or pass in the whole config to the build function:
 ```python
-from hezar import build_model, BERTConfig
+from hezar.builders import build_model
+from hezar.models import BERTConfig
 
 bert = build_model("bert", BERTConfig(hidden_act="gelu", hidden_size=840))
 ```
@@ -171,7 +172,7 @@ class TextClassificationModel(Model):
 ```
 You can inspect the preprocessor for any model like below:
 ```python
-from hezar import Model
+from hezar.models import Model
 
 whisper = Model.load("hezarai/whisper-small-fa")
 whisper_preprocessors = whisper.preprocessor
@@ -208,7 +209,7 @@ All Hezar models can be easily saved, loaded and pushed to hub in the same way.
 Loading models is done by using the `.load()` method. This method takes in the path to the desired model which can be
 a path on the Hub or a path on your local disk.
 ```python
-from hezar import Model
+from hezar.models import Model
 
 whisper = Model.load("hezarai/whisper-small-fa")
 whisper.save("my-whisper")

--- a/docs/tutorial/datasets.md
+++ b/docs/tutorial/datasets.md
@@ -16,7 +16,7 @@ xlsum_dataset = load_dataset("hezarai/xlsum-fa")
 
 ### Load using Hezar Dataset
 ```python
-from hezar import Dataset
+from hezar.data import Dataset
 
 sentiment_dataset = Dataset.load("hezarai/sentiment-dksf")  # A TextClassificationDataset instance
 lscp_dataset = Dataset.load("hezarai/lscp-pos-500k")  # A SequenceLabelingDataset instance

--- a/docs/tutorial/models.md
+++ b/docs/tutorial/models.md
@@ -21,7 +21,7 @@ Every model in Hezar, can be pushed to or downloaded from the Hub.
 ### Loading pre-trained models
 Loading a model from Hub is as easy as:
 ```python
-from hezar import Model
+from hezar.models import Model
 
 bert = Model.load("hezarai/bert-base-fa")
 ```
@@ -39,7 +39,7 @@ inference in a single line of code using `Model.predict` method.
 
 A sequence labeling example would be like this:
 ```python
-from hezar import Model
+from hezar.models import Model
 
 pos_model = Model.load("hezarai/bert-fa-pos-lscp-500k")  # Part-of-speech
 inputs = ["شرکت هوش مصنوعی هزار"]
@@ -53,7 +53,7 @@ POS: [[{'token': 'شرکت', 'tag': 'Ne'}, {'token': 'هوش', 'tag': 'Ne'}, {'t
 ### Saving Models
 You can save any model along with its config and preprocessor and other files on disk like:
 ```python
-from hezar import RobertaLM, RobertaLMConfig
+from hezar.models import RobertaLM, RobertaLMConfig
 
 roberta = RobertaLM(RobertaLMConfig(vocab_size=60000))
 roberta.save("my-roberta")
@@ -62,7 +62,7 @@ roberta.save("my-roberta")
 ### Pushing to the Hub
 Every model can be pushed to the Hub.
 ```python
-from hezar import RobertaTextClassification, RobertaTextClassificationConfig
+from hezar.models import RobertaTextClassification, RobertaTextClassificationConfig
 
 roberta = RobertaTextClassification(RobertaTextClassificationConfig(num_labels=2))
 roberta.push_to_hub("arxyzan/roberta-sentiment")
@@ -81,7 +81,8 @@ from dataclasses import dataclass
 
 from torch import Tensor, nn
 
-from hezar import Model, ModelConfig, register_model
+from hezar.models import Model, ModelConfig
+from hezar.registry import register_model
 
 
 @dataclass

--- a/docs/tutorial/preprocessors.md
+++ b/docs/tutorial/preprocessors.md
@@ -11,7 +11,7 @@ Following the common pattern among all modules in Hezar, preprocessors also can 
 **Loading with the corresponding module**<br>
 You can load any preprocessor of any type with its base class like `Tokenizer`, `AudioFeatureExtractor`, etc.
 ```python
-from hezar import Tokenizer, AudioFeatureExtractor, TextNormalizer
+from hezar.preprocessors import Tokenizer, AudioFeatureExtractor, TextNormalizer
 
 tokenizer = Tokenizer.load("hezarai/bert-base-fa")
 normalizer = TextNormalizer.load("hezarai/roberta-base-fa")
@@ -27,7 +27,7 @@ contains single or multiple preprocessors.
 - If path contains multiple preprocessors, the output is a `PreprocessorContainer` which is a dict-like object that holds
 each preprocessor by its registry name.
 ```python
-from hezar import Tokenizer
+from hezar.preprocessors import Tokenizer
 
 tokenizer = Tokenizer.load("hezarai/bert-base-fa")
 print(tokenizer)
@@ -37,7 +37,7 @@ print(tokenizer)
 ```
 
 ```python
-from hezar import Preprocessor
+from hezar.preprocessors import Preprocessor
 
 whisper_preprocessors = Preprocessor.load("hezarai/whisper-small-fa")
 print(whisper_preprocessors)
@@ -56,7 +56,7 @@ PreprocessorsContainer(
 ## Saving & Pushing to the Hub
 Although preprocessor have their own type, they all implement the `load`, `save` and `push_to_hub` methods.
 ```python
-from hezar import TextNormalizer, TextNormalizerConfig
+from hezar.preprocessors import TextNormalizer, TextNormalizerConfig
 
 normalizer = TextNormalizer(TextNormalizerConfig(nfkc=False))
 normalizer.save("my-normalizer")

--- a/docs/tutorial/training.md
+++ b/docs/tutorial/training.md
@@ -11,17 +11,13 @@ text and sentiment pairs collected from SnappFood/Digikala user comments.
 First things first, let's import the required stuff.
 
 ```python
-from hezar import (
-    DistilBertTextClassification,
-    DistilBertTextClassificationConfig,
-    Trainer,
-    TrainerConfig,
-    Dataset,
-    Preprocessor,
-)
+from hezar.models import DistilBertTextClassification, DistilBertTextClassificationConfig
+from hezar.data import Dataset
+from hezar.trainer import Trainer, TrainerConfig
+from hezar.preprocessors import Preprocessor
 ```
 ### Define paths
-Lets define our paths to the datasets, tokenizer, etc.
+Let's define our paths to the datasets, tokenizer, etc.
 ```python
 DATASET_PATH = "hezarai/sentiment-dksf"  # dataset path on the Hub
 BASE_MODEL_PATH = "hezarai/distilbert-base-fa"  # used as model backbone weights and tokenizer

--- a/examples/data/dataset_example.py
+++ b/examples/data/dataset_example.py
@@ -1,6 +1,6 @@
 from torch.utils.data import DataLoader
 
-from hezar.data.datasets import Dataset
+from hezar.data import Dataset
 
 
 dataset = Dataset.load("hezarai/lscp-pos-500k", tokenizer_path="hezarai/distilbert-base-fa")

--- a/examples/embedding/embedding_example.py
+++ b/examples/embedding/embedding_example.py
@@ -1,4 +1,4 @@
-from hezar import Embedding
+from hezar.embeddings import Embedding
 
 
 embedding_model = Embedding.load("hezarai/word2vec-skipgram-fa-wikipedia")

--- a/examples/inference/custom_model_example.py
+++ b/examples/inference/custom_model_example.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import torch
 from torch import Tensor, nn
 
-from hezar import Model, ModelConfig, register_model
+from hezar.models import Model, ModelConfig, register_model
 
 
 @dataclass

--- a/examples/inference/image_captioning_example.py
+++ b/examples/inference/image_captioning_example.py
@@ -1,4 +1,4 @@
-from hezar import Model
+from hezar.models import Model
 
 
 model = Model.load("hezarai/vit-roberta-fa-image-captioning-flickr30k")

--- a/examples/inference/language_modeling_examlple.py
+++ b/examples/inference/language_modeling_examlple.py
@@ -1,4 +1,4 @@
-from hezar import Model
+from hezar.models import Model
 
 
 path = "hezarai/roberta-fa-mlm"

--- a/examples/inference/license_plate_ocr_example.py
+++ b/examples/inference/license_plate_ocr_example.py
@@ -1,4 +1,4 @@
-from hezar import Model
+from hezar.models import Model
 
 
 model = Model.load("hezarai/crnn-fa-64x256-license-plate-recognition")  # CRNN

--- a/examples/inference/ner_tagging_example.py
+++ b/examples/inference/ner_tagging_example.py
@@ -1,4 +1,4 @@
-from hezar import Model
+from hezar.models import Model
 
 
 model = Model.load("hezarai/bert-fa-pos-lscp-500k")

--- a/examples/inference/ocr_example.py
+++ b/examples/inference/ocr_example.py
@@ -1,4 +1,4 @@
-from hezar import Model
+from hezar.models import Model
 
 
 # model = Model.load("hezarai/trocr-base-fa-v1")  # TrOCR

--- a/examples/inference/pos_tagging_example.py
+++ b/examples/inference/pos_tagging_example.py
@@ -1,4 +1,4 @@
-from hezar import Model
+from hezar.models import Model
 
 model = Model.load("hezarai/bert-fa-ner-arman")
 inputs = ["شرکت هوش مصنوعی هزار"]

--- a/examples/inference/sequence_labeling_example.py
+++ b/examples/inference/sequence_labeling_example.py
@@ -1,0 +1,8 @@
+from hezar.models import Model
+
+
+hub_path = "hezarai/bert-fa-pos-lscp-500k"
+model = Model.load(hub_path)
+inputs = ["سلام بر فارسی زبانان شریف"]
+outputs = model.predict(inputs)
+print(outputs)

--- a/examples/inference/speech_recognition_example.py
+++ b/examples/inference/speech_recognition_example.py
@@ -1,4 +1,4 @@
-from hezar import Model
+from hezar.models import Model
 
 
 whisper = Model.load("hezarai/whisper-small-fa")

--- a/examples/inference/text_classification_example.py
+++ b/examples/inference/text_classification_example.py
@@ -1,4 +1,4 @@
-from hezar import Model
+from hezar.models import Model
 
 example = ["هزار، کتابخانه‌ای کامل برای به کارگیری آسان هوش مصنوعی"]
 model = Model.load("hezarai/distilbert-fa-sentiment-dksf")

--- a/examples/inference/text_generation_example.py
+++ b/examples/inference/text_generation_example.py
@@ -1,4 +1,4 @@
-from hezar import Model
+from hezar.models import Model
 
 
 model = Model.load("hezarai/gpt2-base-fa")

--- a/examples/preprocessing/tokenizer_example.py
+++ b/examples/preprocessing/tokenizer_example.py
@@ -1,4 +1,4 @@
-from hezar import Tokenizer
+from hezar.preprocessors import Tokenizer
 
 
 tokenizer = Tokenizer.load(hub_or_local_path="hezarai/roberta-base-fa")

--- a/examples/preprocessing/train_tokenizer_example.py
+++ b/examples/preprocessing/train_tokenizer_example.py
@@ -1,4 +1,4 @@
-from hezar.preprocessors.tokenizers import (
+from hezar.preprocessors import (
     BPEConfig,
     BPETokenizer,
     SentencePieceBPEConfig,

--- a/examples/train/train_ocr_alpr_example.py
+++ b/examples/train/train_ocr_alpr_example.py
@@ -1,11 +1,8 @@
-from hezar import (
-    CRNNImage2TextConfig,
-    CRNNImage2Text,
-    TrainerConfig,
-    Trainer,
-    Dataset,
-    Preprocessor,
-)
+from hezar.models import CRNNImage2TextConfig, CRNNImage2Text
+from hezar.preprocessors import Preprocessor
+from hezar.data import Dataset
+from hezar.trainer import Trainer, TrainerConfig
+
 
 base_model_path = "hezarai/crnn-base-fa-64x256"
 

--- a/examples/train/train_sequence_labeling.py
+++ b/examples/train/train_sequence_labeling.py
@@ -1,11 +1,7 @@
-from hezar import (
-    BertSequenceLabeling,
-    BertSequenceLabelingConfig,
-    Dataset,
-    Preprocessor,
-    Trainer,
-    TrainerConfig,
-)
+from hezar.models import BertSequenceLabeling, BertSequenceLabelingConfig
+from hezar.data import Dataset
+from hezar.preprocessors import Preprocessor
+from hezar.trainer import Trainer, TrainerConfig
 
 
 base_model_path = "hezarai/bert-base-fa"

--- a/examples/train/train_text_classification.py
+++ b/examples/train/train_text_classification.py
@@ -1,11 +1,7 @@
-from hezar import (
-    BertTextClassification,
-    BertTextClassificationConfig,
-    Dataset,
-    Preprocessor,
-    Trainer,
-    TrainerConfig,
-)
+from hezar.models import BertTextClassification, BertTextClassificationConfig
+from hezar.data import Dataset
+from hezar.preprocessors import Preprocessor
+from hezar.trainer import Trainer, TrainerConfig
 
 
 dataset_path = "hezarai/sentiment-dksf"

--- a/hezar/__init__.py
+++ b/hezar/__init__.py
@@ -1,13 +1,57 @@
-from .registry import *
-from .builders import *
-from .configs import *
-from .data import *
-from .embeddings import *
-from .metrics import *
-from .models import *
-from .preprocessors import *
-from .trainer import *
-from .utils import *
+"""
+Direct importing from hezar's root is no longer supported nor recommended since version 0.33.0. The following is just a
+workaround for backward compatibility. Any class, functions, etc. must be imported from its main submodule under hezar.
+"""
+import warnings
 
 
 __version__ = "0.32.1"
+
+
+def _warn_on_import(name: str, submodule: str):
+    warnings.warn(
+        f"Importing {name} from hezar root is deprecated and will be removed soon. "
+        f"Please use `from {submodule} import {name}`"
+    )
+
+
+def __getattr__(name: str):
+    if name == "Model":
+        from hezar.models import Model
+        _warn_on_import(name, "hezar.models")
+        return Model
+    elif name == "Dataset":
+        from .data import Dataset
+        _warn_on_import(name, "hezar.data")
+        return Dataset
+    elif name == "Trainer":
+        from .trainer import Trainer
+        _warn_on_import(name, "hezar.trainer")
+        return Trainer
+    elif name == "Embedding":
+        from .embeddings import Embedding
+        _warn_on_import(name, "hezar.embeddings")
+        return Embedding
+    elif name == "Preprocessor":
+        from .preprocessors import Preprocessor
+        _warn_on_import(name, "hezar.preprocessors")
+        return Preprocessor
+    elif name == "Metric":
+        from .metrics import Metric
+        _warn_on_import(name, "hezar.metrics")
+        return Metric
+    elif "Config" in name:
+        from .configs import Config
+        _warn_on_import(name, "hezar.configs")
+        return Config
+
+
+__all__ = [
+    "Config",
+    "Model",
+    "Dataset",
+    "Trainer",
+    "Preprocessor",
+    "Embedding",
+    "Metric",
+]

--- a/hezar/builders.py
+++ b/hezar/builders.py
@@ -27,7 +27,6 @@ from .registry import (
     models_registry,
     preprocessors_registry,
 )
-from .utils import snake_case
 
 
 __all__ = [
@@ -143,7 +142,6 @@ def build_metric(name: str, config: Optional[MetricConfig] = None, **kwargs):
     """
     if name not in metrics_registry:
         raise ValueError(f"Unknown metric name: `{name}`!\n" f"Available metric names: {list(metrics_registry.keys())}")
-    name = snake_case(name)
     config = config or metrics_registry[name].config_class()
     metric = metrics_registry[name].module_class(config, **kwargs)
     return metric

--- a/hezar/configs.py
+++ b/hezar/configs.py
@@ -4,10 +4,10 @@ as a config container which is an instance of `Config` or its derivatives. A `Co
 auxiliary methods for loading, saving, uploading to the hub and etc.
 
 Examples:
-    >>> from hezar import ModelConfig
+    >>> from hezar.configs import ModelConfig
     >>> config = ModelConfig.load("hezarai/bert-base-fa")
 
-    >>> from hezar import BertLMConfig
+    >>> from hezar.models import BertLMConfig
     >>> bert_config = BertLMConfig(vocab_size=50000, hidden_size=768)
     >>> bert_config.save("saved/bert", filename="model_config.yaml")
     >>> bert_config.push_to_hub("hezarai/bert-custom", filename="model_config.yaml")

--- a/hezar/data/datasets/__init__.py
+++ b/hezar/data/datasets/__init__.py
@@ -1,4 +1,5 @@
-from .dataset import Dataset
+from ...registry import register_dataset  # noqa
+from .dataset import Dataset, DatasetConfig  # noqa
 from .ocr_dataset import OCRDataset, OCRDatasetConfig
 from .sequence_labeling_dataset import SequenceLabelingDataset, SequenceLabelingDatasetConfig
 from .text_classification_dataset import TextClassificationDataset, TextClassificationDatasetConfig

--- a/hezar/embeddings/__init__.py
+++ b/hezar/embeddings/__init__.py
@@ -1,3 +1,4 @@
-from .embedding import Embedding
+from ..registry import register_embedding  # noqa
+from .embedding import Embedding, EmbeddingConfig  # noqa
 from .fasttext import FastText, FastTextConfig
 from .word2vec import Word2Vec, Word2VecConfig

--- a/hezar/metrics/__init__.py
+++ b/hezar/metrics/__init__.py
@@ -1,4 +1,5 @@
-from .metric import Metric
+from ..registry import register_metric  # noqa
+from .metric import Metric, MetricConfig  # noqa
 from .accuracy import Accuracy, AccuracyConfig
 from .bleu import BLEU, BLEUConfig
 from .cer import CER, CERConfig

--- a/hezar/models/__init__.py
+++ b/hezar/models/__init__.py
@@ -1,4 +1,5 @@
-from .model import Model
+from ..registry import register_model  # noqa
+from .model import Model, ModelConfig  # noqa
 from .audio_classification import *
 from .backbone import *
 from .image2text import *

--- a/hezar/models/model.py
+++ b/hezar/models/model.py
@@ -4,7 +4,7 @@ some extra Hezar-specific functionalities and methods e.g, pushing to hub, loadi
 
 Examples:
     >>> # Load from hub
-    >>> from hezar import Model
+    >>> from hezar.models import Model
     >>> model = Model.load("hezarai/bert-base-fa")
 """
 import inspect

--- a/hezar/preprocessors/__init__.py
+++ b/hezar/preprocessors/__init__.py
@@ -1,4 +1,5 @@
-from .preprocessor import Preprocessor, PreprocessorsContainer
+from ..registry import register_preprocessor  # noqa
+from .preprocessor import Preprocessor, PreprocessorConfig, PreprocessorsContainer  # noqa
 from .audio_feature_extractor import AudioFeatureExtractor, AudioFeatureExtractorConfig
 from .image_processor import ImageProcessor, ImageProcessorConfig
 from .text_normalizer import TextNormalizer, TextNormalizerConfig

--- a/hezar/preprocessors/preprocessor.py
+++ b/hezar/preprocessors/preprocessor.py
@@ -5,6 +5,7 @@ from typing import List, Union
 from huggingface_hub import hf_hub_download
 from omegaconf import OmegaConf
 
+from ..configs import PreprocessorConfig
 from ..constants import DEFAULT_PREPROCESSOR_SUBFOLDER, Backends, RegistryType, RepoType, HEZAR_CACHE_DIR
 from ..utils import get_module_class, list_repo_files, verify_dependencies
 
@@ -21,7 +22,7 @@ class Preprocessor:
 
     preprocessor_subfolder = DEFAULT_PREPROCESSOR_SUBFOLDER
 
-    def __init__(self, config, **kwargs):
+    def __init__(self, config: PreprocessorConfig, **kwargs):
         verify_dependencies(self, self.required_backends)  # Check if all the required dependencies are installed
 
         self.config = config.update(kwargs)

--- a/hezar/registry.py
+++ b/hezar/registry.py
@@ -12,7 +12,7 @@ Examples:
     'description': 'Optional model description here...'}
 
     >>> # add a model class to models_registry
-    >>> from hezar import Model, register_model
+    >>> from hezar.models import Model, register_model
     >>> @register_model(name="my_awesome_model", config_class=MyAwesomeModelConfig, description="My Awesome Model!")
     >>> class MyAwesomeModel(Model):
     ...    def __init__(config: MyAwesomeModelConfig):

--- a/hezar/trainer/__init__.py
+++ b/hezar/trainer/__init__.py
@@ -1,3 +1,3 @@
-from .trainer import Trainer
+from .trainer import Trainer, TrainerConfig  # noqa
 from .trainer_utils import *
 from .metrics_handlers import *

--- a/hezar/utils/registry_utils.py
+++ b/hezar/utils/registry_utils.py
@@ -47,26 +47,31 @@ def list_available_embeddings():
 
 def _get_registry_from_type(registry_type: RegistryType):
     if registry_type == RegistryType.MODEL:
+        from ..models import Model  # noqa
         from ..registry import models_registry  # noqa
 
         registry = models_registry
 
     elif registry_type == RegistryType.PREPROCESSOR:
+        from ..preprocessors import Preprocessor  # noqa
         from ..registry import preprocessors_registry  # noqa
 
         registry = preprocessors_registry
 
     elif registry_type == RegistryType.DATASET:
+        from ..data import Dataset  # noqa
         from ..registry import datasets_registry  # noqa
 
         registry = datasets_registry
 
     elif registry_type == RegistryType.EMBEDDING:
+        from ..embeddings import Embedding  # noqa
         from ..registry import embeddings_registry  # noqa
 
         registry = embeddings_registry
 
     elif registry_type == RegistryType.METRIC:
+        from ..metrics import Metric  # noqa
         from ..registry import metrics_registry  # noqa
 
         registry = metrics_registry

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -1,5 +1,5 @@
 def build_models():
-    from hezar import build_model, list_available_models
+    from hezar.models import build_model, list_available_models
 
     for name in list_available_models():
         try:
@@ -10,7 +10,8 @@ def build_models():
 
 
 def build_preprocessors():
-    from hezar import build_preprocessor, list_available_preprocessors
+    from hezar.builders import build_preprocessor
+    from hezar.utils import list_available_preprocessors
 
     for name in list_available_preprocessors():
         try:
@@ -21,7 +22,8 @@ def build_preprocessors():
 
 
 def build_embeddings():
-    from hezar import build_embedding, list_available_embeddings
+    from hezar.builders import build_embedding
+    from hezar.utils import list_available_embeddings
 
     for name in list_available_embeddings():
         try:
@@ -32,7 +34,8 @@ def build_embeddings():
 
 
 def build_datasets():
-    from hezar import build_dataset, list_available_datasets
+    from hezar.builders import build_dataset
+    from hezar.utils import list_available_datasets
 
     for name in list_available_datasets():
         try:
@@ -43,7 +46,8 @@ def build_datasets():
 
 
 def build_metrics():
-    from hezar import build_metric, list_available_metrics
+    from hezar.builders import build_metric
+    from hezar.utils import list_available_metrics
 
     for name in list_available_metrics():
         try:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,5 +1,6 @@
-from hezar import Dataset, Logger
 from hezar.constants import TaskType
+from hezar.data import Dataset
+from hezar.utils import Logger
 
 
 logger = Logger(__name__)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,4 +1,5 @@
-from hezar import Embedding, Logger
+from hezar.embeddings import Embedding
+from hezar.utils import Logger
 
 
 embedding_to_example_repo = {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
-from hezar import Logger, Model
 from hezar.constants import TaskType
+from hezar.models import Model
+from hezar.utils import Logger
 
 
 logger = Logger(__name__)

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -1,4 +1,5 @@
-from hezar import Logger, Tokenizer
+from hezar.preprocessors import Tokenizer
+from hezar.utils import Logger
 
 
 tokenizer_to_example_repo = {


### PR DESCRIPTION
In this PR, regarding #112 issue,  we removed direct imports from hezar's root (`hezar/__init__.py`) and refactored all usages in docs and examples so that now:
```python
from hezar import (
    CRNNImage2TextConfig,
    CRNNImage2Text,
    TrainerConfig,
    Trainer,
    Dataset,
    Preprocessor,
)
```
Must be written like:
```python
# New
from hezar.models import CRNNImage2TextConfig, CRNNImage2Text
from hezar.preprocessors import Preprocessor
from hezar.data import Dataset
from hezar.trainer import Trainer, TrainerConfig
```
