### PR TITLE
:sparkles: Add custom `cache_dir` support for all `load()` methods

### DIFF
--- a/hezar/configs.py
+++ b/hezar/configs.py
@@ -27,7 +27,6 @@ from omegaconf import DictConfig, OmegaConf
 from .constants import DEFAULT_MODEL_CONFIG_FILE, HEZAR_CACHE_DIR, ConfigType, LRSchedulerType, OptimizerType, TaskType
 from .utils import Logger, get_module_config_class
 
-
 __all__ = [
     "Config",
     "ModelConfig",
@@ -141,7 +140,8 @@ class Config:
         hub_or_local_path: str | os.PathLike,
         filename: Optional[str] = None,
         subfolder: Optional[str] = None,
-        repo_type=None,
+        repo_type: str = None,
+        cache_dir: str = None,
         **kwargs,
     ) -> "Config":
         """
@@ -152,6 +152,7 @@ class Config:
             filename: Configuration filename
             subfolder: Optional subfolder path where the config is in
             repo_type: Repo type e.g, model, dataset, etc
+            cache_dir: Path to cache directory
             **kwargs: Manual config parameters to override
 
         Returns:
@@ -172,7 +173,7 @@ class Config:
                 hub_or_local_path,
                 filename=filename,
                 subfolder=subfolder,
-                cache_dir=HEZAR_CACHE_DIR,
+                cache_dir=cache_dir or HEZAR_CACHE_DIR,
                 repo_type=repo_type,
             )
         # Load config file and convert to dictionary

--- a/hezar/data/datasets/dataset.py
+++ b/hezar/data/datasets/dataset.py
@@ -33,7 +33,7 @@ class Dataset(TorchDataset):
     """
     required_backends: List[str | Backends] = None
     config_filename = DEFAULT_DATASET_CONFIG_FILE
-    cache_dir = HEZAR_CACHE_DIR
+    cache_dir = os.path.join(HEZAR_CACHE_DIR, "datasets")
 
     def __init__(self, config: DatasetConfig, split=None, **kwargs):
         """
@@ -84,6 +84,7 @@ class Dataset(TorchDataset):
         hub_path: str | os.PathLike,
         config_filename: Optional[str] = None,
         split: Optional[str | SplitType] = None,
+        cache_dir: str = None,
         **kwargs,
     ) -> "Dataset":
         """
@@ -93,6 +94,7 @@ class Dataset(TorchDataset):
             hub_path (str | os.PathLike): Path to dataset from hub or locally.
             config_filename (Optional[str]): Dataset config file name.
             split (Optional[str | SplitType]): Dataset split, defaults to "train".
+            cache_dir (str): Path to cache directory
             **kwargs: Config parameters as keyword arguments.
 
         Returns:
@@ -101,7 +103,14 @@ class Dataset(TorchDataset):
         """
         split = split or "train"
         config_filename = config_filename or cls.config_filename
-        dataset_config = DatasetConfig.load(hub_path, filename=config_filename, repo_type=RepoType.DATASET)
+        if cache_dir is not None:
+            cls.cache_dir = cache_dir
+        dataset_config = DatasetConfig.load(
+            hub_path,
+            filename=config_filename,
+            repo_type=RepoType.DATASET,
+            cache_dir=cls.cache_dir,
+        )
         dataset_config.path = hub_path
         dataset = build_dataset(dataset_config.name, config=dataset_config, split=split, **kwargs)
         return dataset

--- a/hezar/embeddings/embedding.py
+++ b/hezar/embeddings/embedding.py
@@ -178,6 +178,7 @@ class Embedding:
         embedding_file=None,
         vectors_file=None,
         subfolder=None,
+        cache_dir=None,
         **kwargs,
     ) -> "Embedding":
         """
@@ -189,6 +190,7 @@ class Embedding:
             embedding_file (str): Embedding file name.
             vectors_file (str): Vectors file name.
             subfolder (str): Subfolder within the repository.
+            cache_dir (str): Path to cache directory
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -198,8 +200,14 @@ class Embedding:
         embedding_file = embedding_file or cls.filename
         vectors_file = vectors_file or cls.vectors_filename
         subfolder = subfolder or cls.subfolder
+        cache_dir = cache_dir or HEZAR_CACHE_DIR
 
-        config = EmbeddingConfig.load(hub_or_local_path, filename=config_filename, subfolder=subfolder)
+        config = EmbeddingConfig.load(
+            hub_or_local_path,
+            filename=config_filename,
+            subfolder=subfolder,
+            cache_dir=cache_dir,
+        )
 
         if os.path.isdir(hub_or_local_path):
             embedding_path = os.path.join(hub_or_local_path, subfolder, embedding_file)
@@ -209,14 +217,14 @@ class Embedding:
                 hub_or_local_path,
                 filename=embedding_file,
                 subfolder=subfolder,
-                cache_dir=HEZAR_CACHE_DIR,
+                cache_dir=cache_dir,
                 resume_download=True,
             )
             vectors_path = hf_hub_download(
                 hub_or_local_path,
                 filename=vectors_file,
                 subfolder=subfolder,
-                cache_dir=HEZAR_CACHE_DIR,
+                cache_dir=cache_dir,
                 resume_download=True,
             )
 

--- a/hezar/models/model.py
+++ b/hezar/models/model.py
@@ -104,6 +104,7 @@ class Model(nn.Module):
         model_filename: Optional[str] = None,
         config_filename: Optional[str] = None,
         save_path: Optional[str | os.PathLike] = None,
+        cache_dir: Optional[str | os.PathLike] = None,
         **kwargs,
     ) -> "Model":
         """
@@ -120,6 +121,7 @@ class Model(nn.Module):
             model_filename: Optional model filename.
             config_filename: Optional config filename
             save_path: Save model to this path after loading
+            cache_dir: Path to cache directory, defaults to `~/.cache/hezar`
 
         Returns:
             The fully loaded Hezar model
@@ -128,7 +130,8 @@ class Model(nn.Module):
         device = None or kwargs.pop("device", None)
         # Load config
         config_filename = config_filename or cls.config_filename
-        config = ModelConfig.load(hub_or_local_path=hub_or_local_path, filename=config_filename)
+        cache_dir = cache_dir or HEZAR_CACHE_DIR
+        config = ModelConfig.load(hub_or_local_path=hub_or_local_path, filename=config_filename, cache_dir=cache_dir)
         # Get the exact model class based on registry name under config.name
         model_cls = get_module_class(config.name, registry_type=RegistryType.MODEL)
         # Handle compatibility of model class and the one in the config
@@ -151,7 +154,7 @@ class Model(nn.Module):
             model_path = hf_hub_download(
                 hub_or_local_path,
                 filename=model_filename,
-                cache_dir=HEZAR_CACHE_DIR,
+                cache_dir=cache_dir,
                 resume_download=True,
             )
         else:
@@ -165,7 +168,7 @@ class Model(nn.Module):
             model.save(save_path)
         # Load the preprocessor(s)
         if load_preprocessor:
-            preprocessor = Preprocessor.load(hub_or_local_path, force_return_dict=True)
+            preprocessor = Preprocessor.load(hub_or_local_path, force_return_dict=True, cache_dir=cache_dir)
             model.preprocessor = preprocessor
         return model
 

--- a/hezar/preprocessors/audio_feature_extractor.py
+++ b/hezar/preprocessors/audio_feature_extractor.py
@@ -301,6 +301,7 @@ class AudioFeatureExtractor(Preprocessor):
         hub_or_local_path,
         subfolder: str = None,
         config_filename: str = None,
+        cache_dir: str = None,
         **kwargs,
     ):
         """
@@ -310,6 +311,7 @@ class AudioFeatureExtractor(Preprocessor):
             hub_or_local_path: Hub repo id or local path
             subfolder: Preprocessor subfolder path
             config_filename: Config file name
+            cache_dir: Path to cache directory
             **kwargs:
 
         Returns:
@@ -322,6 +324,7 @@ class AudioFeatureExtractor(Preprocessor):
             hub_or_local_path,
             subfolder=subfolder,
             filename=config_filename,
+            cache_dir=cache_dir,
         )
 
         feature_extractor = build_preprocessor(config.name, config=config, **kwargs)

--- a/hezar/preprocessors/image_processor.py
+++ b/hezar/preprocessors/image_processor.py
@@ -3,6 +3,7 @@ from typing import Iterable, List, Tuple
 
 import numpy as np
 
+from .preprocessor import Preprocessor
 from ..builders import build_preprocessor
 from ..configs import PreprocessorConfig
 from ..constants import (
@@ -23,8 +24,6 @@ from ..utils import (
     resize_image,
     transpose_channels_axis_side,
 )
-from .preprocessor import Preprocessor
-
 
 # List of backends required for the image processor
 _required_backends = [
@@ -176,6 +175,7 @@ class ImageProcessor(Preprocessor):
         subfolder: str = None,
         force_return_dict: bool = False,
         config_filename: str = None,
+        cache_dir: str = None,
         **kwargs,
     ) -> "ImageProcessor":
         """
@@ -186,6 +186,7 @@ class ImageProcessor(Preprocessor):
             subfolder (str): Subfolder within the specified path.
             force_return_dict (bool): Flag to force return as a dictionary.
             config_filename (str): Configuration filename.
+            cache_dir: Path to cache directory
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -193,7 +194,12 @@ class ImageProcessor(Preprocessor):
         """
         subfolder = subfolder or cls.preprocessor_subfolder
         config_filename = config_filename or cls.image_processor_config_file
-        config = ImageProcessorConfig.load(hub_or_local_path, filename=config_filename, subfolder=subfolder)
+        config = ImageProcessorConfig.load(
+            hub_or_local_path,
+            filename=config_filename,
+            subfolder=subfolder,
+            cache_dir=cache_dir,
+        )
         image_processor = build_preprocessor(config.name, config, **kwargs)
         return image_processor
 

--- a/hezar/preprocessors/preprocessor.py
+++ b/hezar/preprocessors/preprocessor.py
@@ -58,6 +58,7 @@ class Preprocessor:
         hub_or_local_path,
         subfolder: str = None,
         force_return_dict: bool = False,
+        cache_dir: str = None,
         **kwargs
     ):
         """
@@ -72,12 +73,14 @@ class Preprocessor:
             hub_or_local_path: Path to hub or local repo
             subfolder: Subfolder for the preprocessor.
             force_return_dict: Whether to return a dict even if there's only one preprocessor available on the repo
+            cache_dir: Path to cache directory
             **kwargs: Extra kwargs
 
         Returns:
             A Preprocessor subclass or a dict of Preprocessor subclass instances
         """
         subfolder = subfolder or cls.preprocessor_subfolder
+        cache_dir = cache_dir or HEZAR_CACHE_DIR
         preprocessor_files = list_repo_files(hub_or_local_path, subfolder=subfolder)
         preprocessors = PreprocessorsContainer()
         for f in preprocessor_files:
@@ -90,13 +93,13 @@ class Preprocessor:
                         filename=f,
                         subfolder=subfolder,
                         repo_type=RepoType.MODEL,
-                        cache_dir=HEZAR_CACHE_DIR,
+                        cache_dir=cache_dir,
                     )
                 config = OmegaConf.load(config_file)
                 name = config.get("name", None)
                 if name:
                     preprocessor_cls = get_module_class(name, registry_type=RegistryType.PREPROCESSOR)
-                    preprocessor = preprocessor_cls.load(hub_or_local_path, subfolder=subfolder)
+                    preprocessor = preprocessor_cls.load(hub_or_local_path, subfolder=subfolder, cache_dir=cache_dir)
                     preprocessors[name] = preprocessor
                 else:
                     raise ValueError(f"The config file `{config_file}` does not have the property `name`!")

--- a/hezar/preprocessors/text_normalizer.py
+++ b/hezar/preprocessors/text_normalizer.py
@@ -91,6 +91,7 @@ class TextNormalizer(Preprocessor):
         hub_or_local_path,
         subfolder=None,
         config_filename=None,
+        cache_dir=None,
         **kwargs
     ) -> "TextNormalizer":
         config_filename = config_filename or cls.normalizer_config_file
@@ -99,6 +100,7 @@ class TextNormalizer(Preprocessor):
             hub_or_local_path,
             filename=config_filename,
             subfolder=subfolder,
+            cache_dir=cache_dir,
         )
         normalizer = build_preprocessor(config.name, config, **kwargs)
         return normalizer

--- a/hezar/preprocessors/tokenizers/tokenizer.py
+++ b/hezar/preprocessors/tokenizers/tokenizer.py
@@ -563,6 +563,7 @@ class Tokenizer(Preprocessor):
         subfolder=None,
         config_filename=None,
         tokenizer_filename=None,
+        cache_dir=None,
         **kwargs,
     ) -> "Tokenizer":
         """
@@ -574,6 +575,7 @@ class Tokenizer(Preprocessor):
             subfolder: Subfolder containing tokenizer files.
             config_filename: Tokenizer config filename.
             tokenizer_filename: Tokenizer filename.
+            cache_dir: Path to cache directory
             **kwargs: Additional arguments.
 
         Returns:
@@ -583,10 +585,13 @@ class Tokenizer(Preprocessor):
         tokenizer_filename = tokenizer_filename or cls.tokenizer_filename
         config_filename = config_filename or cls.tokenizer_config_filename
         subfolder = subfolder or cls.preprocessor_subfolder
+        cache_dir = cache_dir or HEZAR_CACHE_DIR
+
         config = TokenizerConfig.load(
             hub_or_local_path,
             filename=config_filename,
             subfolder=subfolder,
+            cache_dir=cache_dir,
         )
 
         if os.path.isdir(hub_or_local_path):
@@ -596,7 +601,7 @@ class Tokenizer(Preprocessor):
                 hub_or_local_path,
                 filename=tokenizer_filename,
                 subfolder=subfolder,
-                cache_dir=HEZAR_CACHE_DIR,
+                cache_dir=cache_dir,
                 resume_download=True,
             )
         tokenizer = build_preprocessor(config.name, config, tokenizer_file=tokenizer_path, **kwargs)


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief overview of the changes introduced by this pull request. What problem does it solve? -->
This PR adds support for using custom cache directory when loading modules. It can be applied to any Hezar model that has a `.load()` method. Previously, all modules were saved in `~/.cache/hezar/`. 
## Changes
<!-- List the specific changes made in this PR. Bullet points are helpful. -->

- All `load()` methods have a `cache_dir` option to set a custom path for saved modules
- Datasets are now loaded into `~/.cache/hezar/datasets` by default

## Related Issues
<!-- If this PR is related to any GitHub issues, mention them here with the format `Fixes #123` or `Resolves #456`. -->


## Checklist
<!-- Make sure all items in the checklist are completed before submitting the PR. Remove items that are not applicable. -->

- [x] I have read and followed the project's contributing guidelines.
- [x] My code follows the project's coding style.
- [x] I have tested my changes thoroughly.
- [x] I have updated the documentation if necessary.
- [x] All existing tests pass.
- [ ] I have added new tests to cover my changes.
- [x] My changes do not introduce any new warnings or errors.

## Additional Comments
<!-- Any additional information or context that can help reviewers understand your changes better. -->

## Reviewer Instructions
<!-- Provide instructions for the reviewers, if there's anything specific they need to focus on or test. -->

## Author's Note
<!-- Any message or note from the author to the reviewers. -->

