### PR TITLE
Minimal working example of `safetensors` support for `hezar`

### DIFF
--- a/hezar/constants.py
+++ b/hezar/constants.py
@@ -5,7 +5,6 @@ Home to all constant variables in Hezar
 import os
 from enum import Enum
 
-
 HEZAR_HUB_ID = "hezarai"
 HEZAR_CACHE_DIR = os.getenv("HEZAR_CACHE_DIR", f'{os.path.expanduser("~")}/.cache/hezar')
 
@@ -59,6 +58,7 @@ class Backends(ExplicitEnum):
     SCIKIT = "sklearn"
     SEQEVAL = "seqeval"
     ROUGE = "rouge_score"
+    SAFETENSORS = "safetensors"
 
 
 class TaskType(ExplicitEnum):

--- a/hezar/utils/hub_utils.py
+++ b/hezar/utils/hub_utils.py
@@ -1,10 +1,10 @@
 import os
+from pathlib import Path
 
 from huggingface_hub import HfApi, Repository
 
 from ..constants import HEZAR_CACHE_DIR, HEZAR_HUB_ID, RepoType
 from ..utils.logging import Logger
-
 
 __all__ = [
     "resolve_pretrained_path",
@@ -120,12 +120,22 @@ def list_repo_files(hub_or_local_path: str, subfolder: str = None):
                 files.append(f)
             else:
                 for x in f:
-                    files.append(f"{r.replace(f'{hub_or_local_path}/', '')}/{x}")
+                    path = Path(r)
+                    index = path.parts.index(hub_or_local_path)
+                    new_path = Path("").joinpath(*path.parts[:index], *path.parts[index + 1 :], x)
+                    files.append(str(new_path))
     else:
         files = HfApi().list_repo_files(hub_or_local_path, repo_type=str(RepoType.MODEL))
 
     if subfolder is not None:
-        files = [x.replace(f"{subfolder}/", "") for x in files if subfolder in x]
+        new_files = []
+        for i in range(len(files)):
+            if subfolder in files[i]:
+                path = Path(files[i])
+                index = path.parts.index(subfolder)
+                new_path = Path("").joinpath(*path.parts[:index], *path.parts[index + 1 :])
+                new_files.append(str(new_path))
+        files = new_files
 
     return files
 

--- a/tests/test_safetensors.py
+++ b/tests/test_safetensors.py
@@ -1,0 +1,15 @@
+from hezar.models import Model
+
+
+def test_safetensors():
+    example = ["هزار، کتابخانه‌ای کامل برای به کارگیری آسان هوش مصنوعی"]
+
+    pickled_model = Model.load("hezarai/bert-fa-sentiment-dksf")
+    pickled_outputs = pickled_model.predict(example)
+
+    pickled_model.save("safetensors_model", safe_serialization=True)
+
+    safe_model = Model.load("safetensors_model", load_safetensors=True)
+    safe_outputs = safe_model.predict(example)
+
+    assert pickled_outputs == safe_outputs


### PR DESCRIPTION
# Pull Request

## Description
The `save` and `load` methods for the `hezar.models.Model` class have been altered to accommodate for `safetensors` support.  

## Changes
<!-- List the specific changes made in this PR. Bullet points are helpful. -->

- Loading `safetensors` exposed through the keyword argument `load_safetensors` under `Model.load()`.
- Saving `safetensors` exposed through the keyword argument `safe_serialization` under `Model.save()`.
- `SAFETENSORS` added to the `enumlist` of `Backends` in `constants.py`.
- A minimal working example unittest is available at `test_safetensors.py`. This serves just to demonstrate the changes and is by no means a comprehensive test ready for production.

## Related Issues
Resolves #153 

## Additional Comments
**Please keep in mind that this is meant to serve as a draft PR and is by no means production-ready.** The changes made to the code base are very crude and the aim was only to show how it may be possible to incorporate `safetensors` support in `hezar`. After the architectural details and design decisions regarding how and where this change should be introduced within the codebase are approved, I can happily edit this PR (or submit a new one) with a cleaner code that adheres to this library's standards.

## Notes
- `Model.push_to_hub()` also requires changes but for the purposes of this quick prototype it was left unchanged for the time being.
