### PR TITLE
:fire: Use preprocessor container objects explicitly and remove keyed usages

### DIFF
--- a/docs/guide/models_advanced.md
+++ b/docs/guide/models_advanced.md
@@ -160,7 +160,7 @@ class TextClassificationModel(Model):
         ...
 
     def preprocess(self, raw_texts):
-        tokenizer = self.preprocessor["bpe_tokenizer"]
+        tokenizer = self.preprocessor.tokenizer
         model_inputs = tokenizer(raw_texts, return_tensors="torch")
         return model_inputs
 

--- a/docs/tutorial/preprocessors.md
+++ b/docs/tutorial/preprocessors.md
@@ -52,6 +52,12 @@ PreprocessorsContainer(
     ]
 )
 ```
+In order to access specific preprocessor objects within a `PreprocessorContainer` instance, you can use the following
+properties:
+- `tokenizer`: Returns the tokenizer of the container if exists.
+- `text_normalizer`: Returns the text normalizer of the container if exists.
+- `image_processor`: Returns the image processor of the container if exists.
+- `audio_feature_extractor`: Returns the audio feature extractor of the container if exists.
 
 ## Saving & Pushing to the Hub
 Although preprocessor have their own type, they all implement the `load`, `save` and `push_to_hub` methods.

--- a/hezar/models/backbone/bert/bert.py
+++ b/hezar/models/backbone/bert/bert.py
@@ -24,7 +24,6 @@ _required_backends = [
 @register_model("bert", config_class=BERTConfig)
 class BERT(Model):
     required_backends = _required_backends
-    tokenizer_name = "wordpiece_tokenizer"
     skip_keys_on_load = ["model.embeddings.position_ids", "bert.embeddings.position_ids"]  # For older versions
 
     def __init__(self, config, **kwargs):
@@ -67,10 +66,9 @@ class BERT(Model):
     def preprocess(self, inputs: str | List[str], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]
-        if "text_normalizer" in self.preprocessor:
-            normalizer = self.preprocessor["text_normalizer"]
-            inputs = normalizer(inputs)
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        if self.preprocessor.text_normalizer is not None:
+            inputs = self.preprocessor.text_normalizer(inputs)
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(inputs, return_tensors="torch", device=self.device)
         return inputs
 

--- a/hezar/models/backbone/distilbert/distilbert.py
+++ b/hezar/models/backbone/distilbert/distilbert.py
@@ -24,7 +24,6 @@ _required_backends = [
 @register_model("distilbert", config_class=DistilBERTConfig)
 class DistilBERT(Model):
     required_backends = _required_backends
-    tokenizer_name = "wordpiece_tokenizer"
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -54,10 +53,9 @@ class DistilBERT(Model):
     def preprocess(self, inputs: str | List[str], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]
-        if "text_normalizer" in self.preprocessor:
-            normalizer = self.preprocessor["text_normalizer"]
-            inputs = normalizer(inputs)
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        if self.preprocessor.text_normalizer is not None:
+            inputs = self.preprocessor.text_normalizer(inputs)
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(inputs, return_tensors="torch", device=self.device)
         return inputs
 

--- a/hezar/models/backbone/roberta/roberta.py
+++ b/hezar/models/backbone/roberta/roberta.py
@@ -24,7 +24,6 @@ _required_backends = [
 @register_model("roberta", config_class=RoBERTaConfig)
 class RoBERTa(Model):
     required_backends = _required_backends
-    tokenizer_name = "bpe_tokenizer"
     skip_keys_on_load = ["model.embeddings.position_ids", "roberta.embeddings.position_ids"]  # For older versions
 
     def __init__(self, config, **kwargs):
@@ -66,10 +65,9 @@ class RoBERTa(Model):
     def preprocess(self, inputs: str | List[str], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]
-        if "text_normalizer" in self.preprocessor:
-            normalizer = self.preprocessor["text_normalizer"]
-            inputs = normalizer(inputs)
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        if self.preprocessor.text_normalizer is not None:
+            inputs = self.preprocessor.text_normalizer(inputs)
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(inputs, return_tensors="torch", device=self.device)
         return inputs
 

--- a/hezar/models/backbone/vit/vit.py
+++ b/hezar/models/backbone/vit/vit.py
@@ -53,7 +53,7 @@ class ViT(Model):
         return outputs
 
     def preprocess(self, inputs: List[str | np.ndarray | Image.Image | torch.Tensor], **kwargs):
-        image_processor = self.preprocessor[self.image_processor]
+        image_processor = self.preprocessor.image_processor
         processed_outputs = image_processor(inputs, **kwargs)
         return processed_outputs
 

--- a/hezar/models/image2text/beit_roberta/beit_roberta_image2text.py
+++ b/hezar/models/image2text/beit_roberta/beit_roberta_image2text.py
@@ -37,8 +37,6 @@ class BeitRobertaImage2Text(Model):
 
     is_generative = True
     required_backends = _required_backends
-    image_processor = "image_processor"
-    tokenizer_name = "bpe_tokenizer"
     loss_func_name = "cross_entropy"
 
     def __init__(self, config: BeitRobertaImage2TextConfig, **kwargs):
@@ -88,12 +86,12 @@ class BeitRobertaImage2Text(Model):
         return outputs
 
     def preprocess(self, inputs: List[str] | List[np.ndarray] | List[Image] | List[torch.Tensor], **kwargs):
-        image_processor = self.preprocessor[self.image_processor]
+        image_processor = self.preprocessor.image_processor
         processed_outputs = image_processor(inputs, **kwargs)
         return processed_outputs
 
     def post_process(self, model_outputs, **kwargs):
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         decoded_outputs = tokenizer.decode(model_outputs.cpu().numpy().tolist())
         outputs = [Image2TextOutput(text=text) for text in decoded_outputs]
         return outputs

--- a/hezar/models/image2text/crnn/crnn_image2text.py
+++ b/hezar/models/image2text/crnn/crnn_image2text.py
@@ -76,7 +76,7 @@ class CRNNImage2Text(Model):
         return {"generated_ids": output_ids, "scores": mean_probs}
 
     def preprocess(self, inputs, **kwargs):
-        image_processor = self.preprocessor[self.image_processor]
+        image_processor = self.preprocessor.image_processor
         processed_outputs = image_processor(inputs, **kwargs)
         return processed_outputs
 

--- a/hezar/models/image2text/trocr/trocr_image2text.py
+++ b/hezar/models/image2text/trocr/trocr_image2text.py
@@ -37,8 +37,6 @@ class TrOCRImage2Text(Model):
 
     is_generative = True
     required_backends = _required_backends
-    image_processor = "image_processor"
-    tokenizer_name = "bpe_tokenizer"
     loss_func_name = "cross_entropy"
 
     def __init__(self, config: TrOCRImage2TextConfig, **kwargs):
@@ -88,12 +86,12 @@ class TrOCRImage2Text(Model):
         return outputs
 
     def preprocess(self, inputs: List[str | np.ndarray | Image.Image | torch.Tensor], **kwargs):
-        image_processor = self.preprocessor[self.image_processor]
+        image_processor = self.preprocessor.image_processor
         processed_outputs = image_processor(inputs, **kwargs)
         return processed_outputs
 
     def post_process(self, model_outputs, **kwargs):
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         decoded_outputs = tokenizer.decode(model_outputs.cpu().numpy().tolist())
         outputs = [Image2TextOutput(text=text) for text in decoded_outputs]
         return outputs

--- a/hezar/models/image2text/vit_gpt2/vit_gpt2_image2text.py
+++ b/hezar/models/image2text/vit_gpt2/vit_gpt2_image2text.py
@@ -37,8 +37,6 @@ class ViTGPT2Image2Text(Model):
 
     is_generative = True
     required_backends = _required_backends
-    image_processor = "image_processor"
-    tokenizer_name = "bpe_tokenizer"
     loss_func_name = "cross_entropy"
 
     def __init__(self, config: ViTGPT2Image2TextConfig, **kwargs):
@@ -88,12 +86,12 @@ class ViTGPT2Image2Text(Model):
         return outputs
 
     def preprocess(self, inputs: List[str | np.ndarray | Image.Image | torch.Tensor], **kwargs):
-        image_processor = self.preprocessor[self.image_processor]
+        image_processor = self.preprocessor.image_processor
         processed_outputs = image_processor(inputs, **kwargs)
         return processed_outputs
 
     def post_process(self, model_outputs, **kwargs):
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         decoded_outputs = tokenizer.decode(model_outputs.cpu().numpy().tolist())
         outputs = [Image2TextOutput(text=text) for text in decoded_outputs]
         return outputs

--- a/hezar/models/image2text/vit_roberta/vit_roberta_image2text.py
+++ b/hezar/models/image2text/vit_roberta/vit_roberta_image2text.py
@@ -38,7 +38,6 @@ class ViTRobertaImage2Text(Model):
     is_generative = True
     required_backends = _required_backends
     image_processor = "image_processor"
-    tokenizer_name = "bpe_tokenizer"
     loss_func_name = "cross_entropy"
 
     def __init__(self, config: ViTRobertaImage2TextConfig, **kwargs):
@@ -81,7 +80,7 @@ class ViTRobertaImage2Text(Model):
         return loss
 
     def generate(self, pixel_values, generation_config=None, **kwargs):
-        tokenizer = self.preprocessor["bpe_tokenizer"]
+        tokenizer = self.preprocessor.tokenizer
         if generation_config is None:
             generation_config = self.config.dict()["generation"]
             generation_config["decoder_start_token_id"] = tokenizer.pad_token_id
@@ -91,12 +90,12 @@ class ViTRobertaImage2Text(Model):
         return outputs
 
     def preprocess(self, inputs: List[str | np.ndarray | Image.Image | torch.Tensor], **kwargs):
-        image_processor = self.preprocessor[self.image_processor]
+        image_processor = self.preprocessor.image_processor
         processed_outputs = image_processor(inputs, **kwargs)
         return processed_outputs
 
     def post_process(self, model_outputs: torch.Tensor, **kwargs):
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         decoded_outputs = tokenizer.decode(model_outputs.cpu().numpy().tolist())
         outputs = [Image2TextOutput(text=text) for text in decoded_outputs]
         return outputs

--- a/hezar/models/mask_filling/bert/bert_mask_filling.py
+++ b/hezar/models/mask_filling/bert/bert_mask_filling.py
@@ -24,7 +24,6 @@ _required_backends = [
 @register_model("bert_mask_filling", config_class=BertMaskFillingConfig)
 class BertMaskFilling(Model):
     required_backends = _required_backends
-    tokenizer_name = "wordpiece_tokenizer"
     skip_keys_on_load = ["model.embeddings.position_ids", "bert.embeddings.position_ids"]  # For older versions
     loss_func_name = "cross_entropy"
 
@@ -72,7 +71,7 @@ class BertMaskFilling(Model):
         if isinstance(inputs, str):
             inputs = [inputs]
 
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
 
         for text in inputs:
             if tokenizer.mask_token not in text:
@@ -85,7 +84,7 @@ class BertMaskFilling(Model):
         output_logits = model_outputs.get("logits")
         token_ids = model_outputs.get("token_ids")
 
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         mask_token_id = tokenizer.mask_token_id
 
         unfilled_token_ids = token_ids.cpu().numpy().copy()

--- a/hezar/models/mask_filling/distilbert/distilbert_mask_filling.py
+++ b/hezar/models/mask_filling/distilbert/distilbert_mask_filling.py
@@ -24,7 +24,6 @@ _required_backends = [
 @register_model("distilbert_mask_filling", config_class=DistilBertMaskFillingConfig)
 class DistilBertMaskFilling(Model):
     required_backends = _required_backends
-    tokenizer_name = "wordpiece_tokenizer"
     loss_func_name = "cross_entropy"
 
     def __init__(self, config, **kwargs):
@@ -64,7 +63,7 @@ class DistilBertMaskFilling(Model):
         if isinstance(inputs, str):
             inputs = [inputs]
 
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
 
         for text in inputs:
             if tokenizer.mask_token not in text:
@@ -77,7 +76,7 @@ class DistilBertMaskFilling(Model):
         output_logits = model_outputs.get("logits")
         token_ids = model_outputs.get("token_ids")
 
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         mask_token_id = tokenizer.mask_token_id
 
         unfilled_token_ids = token_ids.cpu().numpy().copy()

--- a/hezar/models/mask_filling/roberta/roberta_mask_filling.py
+++ b/hezar/models/mask_filling/roberta/roberta_mask_filling.py
@@ -27,7 +27,6 @@ _required_backends = [
 @register_model("roberta_mask_filling", config_class=RobertaMaskFillingConfig)
 class RobertaMaskFilling(Model):
     required_backends = _required_backends
-    tokenizer_name = "bpe_tokenizer"
     skip_keys_on_load = ["model.embeddings.position_ids", "roberta.embeddings.position_ids"]  # For older versions
     loss_func_name = "cross_entropy"
 
@@ -74,7 +73,7 @@ class RobertaMaskFilling(Model):
         if isinstance(inputs, str):
             inputs = [inputs]
 
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
 
         for text in inputs:
             if tokenizer.mask_token not in text:
@@ -87,7 +86,7 @@ class RobertaMaskFilling(Model):
         output_logits = model_outputs.get("logits")
         token_ids = model_outputs.get("token_ids")
 
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         mask_token_id = tokenizer.mask_token_id
 
         unfilled_token_ids = token_ids.cpu().numpy().copy()

--- a/hezar/models/sequence_labeling/bert/bert_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/bert/bert_sequence_labeling.py
@@ -32,7 +32,6 @@ class BertSequenceLabeling(Model):
     """
 
     required_backends = _required_backends
-    tokenizer_name = "wordpiece_tokenizer"
     skip_keys_on_load = ["model.embeddings.position_ids", "bert.embeddings.position_ids"]  # For older versions
 
     def __init__(self, config: BertSequenceLabelingConfig, **kwargs):
@@ -96,10 +95,9 @@ class BertSequenceLabeling(Model):
     def preprocess(self, inputs: str | List[str], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]
-        if "text_normalizer" in self.preprocessor:
-            normalizer = self.preprocessor["text_normalizer"]
-            inputs = normalizer(inputs)
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        if self.preprocessor.text_normalizer is not None:
+            inputs = self.preprocessor.text_normalizer(inputs)
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(
             inputs,
             return_word_ids=True,

--- a/hezar/models/sequence_labeling/distilbert/distilbert_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/distilbert/distilbert_sequence_labeling.py
@@ -28,7 +28,6 @@ _required_backends = [
 @register_model("distilbert_sequence_labeling", DistilBertSequenceLabelingConfig)
 class DistilBertSequenceLabeling(Model):
     required_backends = _required_backends
-    tokenizer_name = "wordpiece_tokenizer"
 
     def __init__(self, config: DistilBertSequenceLabelingConfig, **kwargs):
         super().__init__(config, **kwargs)
@@ -92,10 +91,9 @@ class DistilBertSequenceLabeling(Model):
     def preprocess(self, inputs: str | List[str], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]
-        if "text_normalizer" in self.preprocessor:
-            normalizer = self.preprocessor["text_normalizer"]
-            inputs = normalizer(inputs)
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        if self.preprocessor.text_normalizer is not None:
+            inputs = self.preprocessor.text_normalizer(inputs)
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(
             inputs,
             return_word_ids=True,

--- a/hezar/models/sequence_labeling/roberta/roberta_sequence_labeling.py
+++ b/hezar/models/sequence_labeling/roberta/roberta_sequence_labeling.py
@@ -35,7 +35,6 @@ class RobertaSequenceLabeling(Model):
     """
 
     required_backends = _required_backends
-    tokenizer_name = "bpe_tokenizer"
     skip_keys_on_load = ["roberta.embeddings.position_ids", "model.embeddings.position_ids"]
 
     def __init__(self, config, **kwargs):
@@ -95,10 +94,9 @@ class RobertaSequenceLabeling(Model):
     def preprocess(self, inputs: str | List[str], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]
-        if "text_normalizer" in self.preprocessor:
-            normalizer = self.preprocessor["text_normalizer"]
-            inputs = normalizer(inputs)
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        if self.preprocessor.text_normalizer is not None:
+            inputs = self.preprocessor.text_normalizer(inputs)
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(
             inputs,
             return_word_ids=True,

--- a/hezar/models/speech_recognition/whisper/whisper_speech_recognition.py
+++ b/hezar/models/speech_recognition/whisper/whisper_speech_recognition.py
@@ -35,8 +35,6 @@ class WhisperSpeechRecognition(Model):
 
     is_generative = True
     required_backends = _required_backends
-    feature_extractor_name = "whisper_feature_extractor"
-    tokenizer_name = "whisper_bpe_tokenizer"
     loss_func_name = "cross_entropy"
 
     def __init__(self, config: WhisperSpeechRecognitionConfig, **kwargs):
@@ -174,10 +172,10 @@ class WhisperSpeechRecognition(Model):
         elif isinstance(inputs, List) and isinstance(inputs[0], np.ndarray):
             inputs = [librosa.to_mono(x.transpose()) for x in inputs if isinstance(x, np.ndarray) and len(x.shape) > 1]
 
-        tokenizer = self.preprocessor[self.tokenizer_name]
-        feature_extractor = self.preprocessor[self.feature_extractor_name]
+        tokenizer = self.preprocessor.tokenizer
+        feature_extractor = self.preprocessor.audio_feature_extractor
 
-        forced_decoder_ids = tokenizer.get_decoder_prompt_ids(language="persian", task="transcribe")
+        forced_decoder_ids = tokenizer.get_decoder_prompt_ids(language=tokenizer.language, task="transcribe")
         inputs = feature_extractor(inputs, sampling_rate=self.config.sampling_rate, return_tensors="torch")
         inputs["forced_decoder_ids"] = forced_decoder_ids
         return inputs
@@ -190,7 +188,7 @@ class WhisperSpeechRecognition(Model):
         output_offsets=False,
         **kwargs,
     ):
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         if isinstance(model_outputs, torch.Tensor):
             model_outputs = model_outputs.cpu().numpy().tolist()
         transcripts = tokenizer.decode(

--- a/hezar/models/text_classification/bert/bert_text_classification.py
+++ b/hezar/models/text_classification/bert/bert_text_classification.py
@@ -35,7 +35,6 @@ class BertTextClassification(Model):
     """
 
     required_backends = _required_backends
-    tokenizer_name = "wordpiece_tokenizer"
     skip_keys_on_load = [
         "model.embeddings.position_ids",  # For older versions
         "bert.embeddings.position_ids",
@@ -109,10 +108,9 @@ class BertTextClassification(Model):
     def preprocess(self, inputs: str | List[str], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]
-        if "text_normalizer" in self.preprocessor:
-            normalizer = self.preprocessor["text_normalizer"]
-            inputs = normalizer(inputs)
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        if self.preprocessor.text_normalizer is not None:
+            inputs = self.preprocessor.text_normalizer(inputs)
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(inputs, return_tensors="torch", device=self.device)
         return inputs
 

--- a/hezar/models/text_classification/distilbert/distilbert_text_classification.py
+++ b/hezar/models/text_classification/distilbert/distilbert_text_classification.py
@@ -35,7 +35,6 @@ class DistilBertTextClassification(Model):
     """
 
     required_backends = _required_backends
-    tokenizer_name = "wordpiece_tokenizer"
 
     def __init__(self, config: DistilBertTextClassificationConfig, **kwargs):
         super().__init__(config, **kwargs)
@@ -93,10 +92,9 @@ class DistilBertTextClassification(Model):
     def preprocess(self, inputs: str | List[str], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]
-        if "text_normalizer" in self.preprocessor:
-            normalizer = self.preprocessor["text_normalizer"]
-            inputs = normalizer(inputs)
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        if self.preprocessor.text_normalizer is not None:
+            inputs = self.preprocessor.text_normalizer(inputs)
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(inputs, return_tensors="torch", device=self.device)
         return inputs
 

--- a/hezar/models/text_classification/roberta/roberta_text_classification.py
+++ b/hezar/models/text_classification/roberta/roberta_text_classification.py
@@ -35,7 +35,6 @@ class RobertaTextClassification(Model):
     """
 
     required_backends = _required_backends
-    tokenizer_name = "bpe_tokenizer"
     skip_keys_on_load = ["model.embeddings.position_ids", "roberta.embeddings.position_ids"]  # For older versions
 
     def __init__(self, config, **kwargs):
@@ -93,10 +92,9 @@ class RobertaTextClassification(Model):
     def preprocess(self, inputs: str | List[str], **kwargs):
         if isinstance(inputs, str):
             inputs = [inputs]
-        if "text_normalizer" in self.preprocessor:
-            normalizer = self.preprocessor["text_normalizer"]
-            inputs = normalizer(inputs)
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        if self.preprocessor.text_normalizer is not None:
+            inputs = self.preprocessor.text_normalizer(inputs)
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(inputs, return_tensors="torch", device=self.device)
         return inputs
 

--- a/hezar/models/text_generation/gpt2/gpt2_text_generation.py
+++ b/hezar/models/text_generation/gpt2/gpt2_text_generation.py
@@ -25,7 +25,6 @@ _required_backends = [Backends.TRANSFORMERS, Backends.TOKENIZERS]
 @register_model("gpt2_text_generation", config_class=GPT2TextGenerationConfig)
 class GPT2TextGeneration(Model):
     is_generative = True
-    tokenizer_name = "bpe_tokenizer"
     required_backends = _required_backends
     loss_func_name = "cross_entropy"
 
@@ -84,12 +83,12 @@ class GPT2TextGeneration(Model):
         return generated_ids
 
     def preprocess(self, texts: str | List[str], **kwargs):
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(texts, return_tensors="torch", device=self.device)
         return inputs
 
     def post_process(self, generated_ids: torch.Tensor):
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         decoded_outputs = tokenizer.decode(generated_ids.cpu().numpy().tolist())
         outputs = [TextGenerationOutput(text=text) for text in decoded_outputs]
         return outputs

--- a/hezar/models/text_generation/t5/t5_text_generation.py
+++ b/hezar/models/text_generation/t5/t5_text_generation.py
@@ -29,7 +29,6 @@ class T5TextGeneration(Model):
 
     is_generative = True
     required_backends = _required_backends
-    tokenizer_name = "sentencepiece_unigram_tokenizer"
     loss_func_name = "cross_entropy"
 
     def __init__(self, config: T5TextGenerationConfig, **kwargs):
@@ -103,12 +102,12 @@ class T5TextGeneration(Model):
         prefix = prefix or self.config.input_prefix
         if prefix:
             inputs = [f"{prefix}{x}" for x in inputs]
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         inputs = tokenizer(inputs, return_tensors="torch", device=self.device)
         return inputs
 
     def post_process(self, generated_ids: torch.Tensor, **kwargs):
-        tokenizer = self.preprocessor[self.tokenizer_name]
+        tokenizer = self.preprocessor.tokenizer
         decoded_outputs = tokenizer.decode(generated_ids.cpu().numpy().tolist())
         outputs = [TextGenerationOutput(text=text) for text in decoded_outputs]
         return outputs

--- a/hezar/preprocessors/tokenizers/tokenizer.py
+++ b/hezar/preprocessors/tokenizers/tokenizer.py
@@ -184,9 +184,7 @@ class Tokenizer(Preprocessor):
         """
         if isinstance(ids[0], int):
             ids = [ids]
-        if isinstance(ids, torch.Tensor):
-            ids = ids.cpu().numpy().tolist()
-        if isinstance(ids, np.ndarray):
+        if isinstance(ids, (torch.Tensor, np.ndarray)):
             ids = ids.tolist()
         return self._tokenizer.decode_batch(ids, skip_special_tokens=skip_special_tokens)
 


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief overview of the changes introduced by this pull request. What problem does it solve? -->
All preprocessor usages in models are performed using the properties in the `PreprocessorContainer` (`tokenizer`, `audio_feature_extractor`, `image_processor`, `text_normalizer`)

#### Old
```python
tokenizer = self.preprocessor["bpe_tokenizer"]
```
#### New
```python
tokenizer = self.preprocessor.tokenizer
```
